### PR TITLE
Remove dependency on apso-core from apso-profiling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val encryption    = module(project, "encryption").dependsOn(log)
 lazy val hashing       = module(project, "hashing")
 lazy val io            = module(project, "io").dependsOn(aws, testkit % Test)
 lazy val log           = module(project, "log")
-lazy val profiling     = module(project, "profiling").dependsOn(core, log)
+lazy val profiling     = module(project, "profiling").dependsOn(log)
 lazy val testkit       = module(project, "testkit")
 lazy val time          = module(project, "time")
 

--- a/profiling/src/main/scala/com/velocidi/apso/profiling/SimpleJmx.scala
+++ b/profiling/src/main/scala/com/velocidi/apso/profiling/SimpleJmx.scala
@@ -1,19 +1,29 @@
 package com.velocidi.apso.profiling
 
+import java.net.ServerSocket
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 import com.j256.simplejmx.server.JmxServer
 
-import com.velocidi.apso.{Logging, NetUtils}
+import com.velocidi.apso.Logging
 
 trait SimpleJmx extends Logging {
 
   def startJmx(jmxConfig: config.Jmx): Future[JmxServer] = {
 
     def tryStart(port: Option[Int] = None) = {
-      val jmx = new JmxServer(port.getOrElse(NetUtils.availablePort()))
+      // Returns an unused port.
+      def availablePort(): Int = {
+        val socket = new ServerSocket(0)
+        val port = socket.getLocalPort
+        socket.close()
+        port
+      }
+
+      val jmx = new JmxServer(port.getOrElse(availablePort()))
       jmx.start()
       jmx
     }


### PR DESCRIPTION
apso-profiling only needs apso-core for `NetUtils`, whose implementation is so simple we can replicate it there, avoiding a rather bulky dependency.