### PR TITLE
Add option to log all warnings as errors in `ElasticsearchBulkinserter`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ target/
 .bloop
 .metals
 metals.sbt
+
+# VS Code
+.vscode


### PR DESCRIPTION
This gives us the ability to log messages like `Elasticsearch is down...` as an error instead of a warning