### PR TITLE
Update actions used in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: adopt@1.8
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK and sbt
-        uses: olafurpg/setup-scala@v13
+      - name: Set up JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8
+          distribution: adopt
+          java-version: 8
 
       - name: Cache sbt
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK and sbt
         uses: olafurpg/setup-scala@v13


### PR DESCRIPTION
This updates the actions used in the CI pipeline since we have been getting some deprecation warnings (see https://github.com/adzerk/apso/actions/runs/3481258143 for an example). 

The move away from [olafurpg/setup-scala](https://github.com/olafurpg/setup-scala) is because (1) the project is likely to be archived (https://github.com/olafurpg/setup-scala/issues/49) and (2) sbt is now bundled with GitHub's runners, so we can rely on [actions/setup-java](https://github.com/actions/setup-java) only.