### PR TITLE
Replace actions/cache with coursier/cache-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,7 @@ jobs:
           java-version: 8
 
       - name: Cache sbt
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+        uses: coursier/cache-action@v6
 
       - name: Compile and check format
         run: >-


### PR DESCRIPTION
Using coursier/cache-action directly removes the need to specify the cache directories. The action takes care of that for us.