### PR TITLE
Add asdf's .tool-versions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ metals.sbt
 
 # VS Code
 .vscode
+
+# asdf
+.tool-versions


### PR DESCRIPTION
Cherry-picked from #380. I was about to do a similar change in a different branch, so we might as well get this in separately.