### PR TITLE
Add a `lastModifiedTimestamp` method to `FileDescriptor`

### DIFF
--- a/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
@@ -112,6 +112,20 @@ class S3Bucket(
     s3.getObjectMetadata(bucketName, key).getContentLength
   }.getOrElse(0)
 
+  /** Returns the last modified timestamp of the file in the location specified by `key` in the bucket. If the file
+    * doesn't exist the return value is 0L. The decision to return 0L in those cases is to align with
+    * `java.io.File#lastModified()`'s behavior.
+    *
+    * @param key
+    *   the remote pathname for the file
+    * @return
+    *   the last modified timestamp of the file in the location specified by `key` in the bucket if it exists, 0L
+    *   otherwise.
+    */
+  def lastModified(key: String): Long = retry {
+    s3.getObjectMetadata(bucketName, key).getLastModified().getTime()
+  }.getOrElse(0)
+
   /** Returns a list of objects in a bucket matching a given prefix.
     *
     * @param prefix

--- a/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
@@ -122,9 +122,8 @@ class S3Bucket(
     *   the last modified timestamp of the file in the location specified by `key` in the bucket if it exists, 0L
     *   otherwise.
     */
-  def lastModified(key: String): Long = retry {
-    s3.getObjectMetadata(bucketName, key).getLastModified().getTime()
-  }.getOrElse(0)
+  def lastModified(key: String): Long =
+    retry(s3.getObjectMetadata(bucketName, key).getLastModified().getTime()).getOrElse(0)
 
   /** Returns a list of objects in a bucket matching a given prefix.
     *

--- a/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/FileDescriptor.scala
@@ -29,6 +29,10 @@ trait FileDescriptor {
     */
   def size: Long
 
+  /** The last modified timestamp of the file associated with the file descriptor.
+    */
+  def lastModifiedTimestamp: Long
+
   /** Downloads the file to the given local destination. Both the source and the destination must point to a file.
     *
     * @param localTarget

--- a/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/LocalFileDescriptor.scala
@@ -30,6 +30,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
 
   def size = file.length()
 
+  def lastModifiedTimestamp = file.lastModified()
+
   def parent(n: Int): LocalFileDescriptor = {
     val parentPath = (1 to n).foldLeft(normalizedPath)((acc, _) => acc.getParent)
     LocalFileDescriptor(parentPath.toString)

--- a/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
@@ -36,6 +36,11 @@ case class S3FileDescriptor(
     case None       => bucket.size(builtPath)
   }
 
+  def lastModifiedTimestamp = summary match {
+    case Some(info) => info.getLastModified().getTime()
+    case None       => bucket.lastModified(builtPath)
+  }
+
   def download(localTarget: LocalFileDescriptor, safeDownloading: Boolean): Boolean = {
     if (localTarget.isDirectory) {
       throw new Exception("File descriptor points to a directory")

--- a/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/S3FileDescriptor.scala
@@ -36,10 +36,7 @@ case class S3FileDescriptor(
     case None       => bucket.size(builtPath)
   }
 
-  def lastModifiedTimestamp = summary match {
-    case Some(info) => info.getLastModified().getTime()
-    case None       => bucket.lastModified(builtPath)
-  }
+  def lastModifiedTimestamp = summary.fold(bucket.lastModified(builtPath))(_.getLastModified().getTime())
 
   def download(localTarget: LocalFileDescriptor, safeDownloading: Boolean): Boolean = {
     if (localTarget.isDirectory) {

--- a/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -103,6 +103,8 @@ case class SftpFileDescriptor(
 
   def size = withFileAttributes(_.getSize)
 
+  def lastModifiedTimestamp = withFileAttributes(_.getMtime())
+
   def isDirectory: Boolean = withFileAttributes(_.getType == FileMode.Type.DIRECTORY)
 
   def exists: Boolean = fileAttributes.isDefined || sftp(c => c.statExistence(path) != null)

--- a/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
@@ -31,18 +31,16 @@ class LocalFileDescriptorSpec extends Specification {
 
     "retrieve the last modified timestamp of a file" in {
       // We're relying on IO being slow here. There's a good chance a very fast IO will result in the same timestamps
-      // for `before`, `lm1`, `lm2` and `after`. Either way, these checks should all hold as invariants, even if looking
-      // at an additional last modified timestamp (`lm2`) doesn't add much to the test.
+      // for `lm1`, `lm2` and `lm3`. Either way, these checks should all hold as invariants.
       val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
-      val before = System.currentTimeMillis()
       fd1.write("hello world")
       val lm1 = fd1.lastModifiedTimestamp
-      lm1 must be_>=(before)
-      fd1.write("hello world!")
+      fd1.write("hello world1")
       val lm2 = fd1.lastModifiedTimestamp
       lm2 must be_>=(lm1)
-      val after = System.currentTimeMillis()
-      lm2 must be_<=(after)
+      fd1.write("hello world2")
+      val lm3 = fd1.lastModifiedTimestamp
+      lm3 must be_>=(lm2)
     }
 
     "move up the hierarchy correctly" in {

--- a/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
@@ -29,6 +29,22 @@ class LocalFileDescriptorSpec extends Specification {
       fd1.size === "hello world".getBytes.length
     }
 
+    "retrieve the last modified timestamp of a file" in {
+      // We're relying on IO being slow here. There's a good chance a very fast IO will result in the same timestamps
+      // for `before`, `lm1`, `lm2` and `after`. Either way, these should all hold as invariants, even if looking at an
+      // additional last modified timestamp (`lm2`) might not add much to the test.
+      val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
+      val before = System.currentTimeMillis()
+      fd1.write("hello world")
+      val lm1 = fd1.lastModifiedTimestamp
+      lm1 must be_>=(before)
+      fd1.write("hello world!")
+      val lm2 = fd1.lastModifiedTimestamp
+      lm2 must be_>=(lm1)
+      val after = System.currentTimeMillis()
+      lm2 must be_<=(after)
+    }
+
     "move up the hierarchy correctly" in {
       LocalFileDescriptor("/tmp/one/two/three").parent() == LocalFileDescriptor("/tmp/one/two")
       LocalFileDescriptor("/tmp/one/two/three").parent(3) == LocalFileDescriptor("/tmp")

--- a/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/velocidi/apso/io/LocalFileDescriptorSpec.scala
@@ -31,8 +31,8 @@ class LocalFileDescriptorSpec extends Specification {
 
     "retrieve the last modified timestamp of a file" in {
       // We're relying on IO being slow here. There's a good chance a very fast IO will result in the same timestamps
-      // for `before`, `lm1`, `lm2` and `after`. Either way, these should all hold as invariants, even if looking at an
-      // additional last modified timestamp (`lm2`) might not add much to the test.
+      // for `before`, `lm1`, `lm2` and `after`. Either way, these checks should all hold as invariants, even if looking
+      // at an additional last modified timestamp (`lm2`) doesn't add much to the test.
       val fd1 = LocalFileDescriptor("/tmp") / randomFolder / randomString
       val before = System.currentTimeMillis()
       fd1.write("hello world")


### PR DESCRIPTION
This pull request adds a `lastModifiedTimestamp` method to `FileDescriptor` exposing the last modified timestamp of the file the `FileDescriptor` points to.