### PR TITLE
Bump elasticsearch to latest version within major `v7.x.x`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,6 +93,7 @@ lazy val commonSettings = Seq(
         "Spray Repository"                  at  "https://repo.spray.io/",
         "Bintray Scalaz Releases"           at  "https://dl.bintray.com/scalaz/releases",
         "JCenter Repository"                at  "https://jcenter.bintray.com/",
+        // Necessary for org.codelibs:elasticsearch-cluster-runner, which moved to maven.codelibs.org after v7.11.x
         "Elasticsearch Cluster Repository"  at  "https://maven.codelibs.org/"
       ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -90,9 +90,10 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeOssRepos("snapshots") ++
       Seq(
         Resolver.typesafeRepo("snapshots"),
-        "Spray Repository"              at "https://repo.spray.io/",
-        "Bintray Scalaz Releases"       at "https://dl.bintray.com/scalaz/releases",
-        "JCenter Repository"            at "https://jcenter.bintray.com/"
+        "Spray Repository"                  at  "https://repo.spray.io/",
+        "Bintray Scalaz Releases"           at  "https://dl.bintray.com/scalaz/releases",
+        "JCenter Repository"                at  "https://jcenter.bintray.com/",
+        "Elasticsearch Cluster Repository"  at  "https://maven.codelibs.org/"
       ),
 
   scalafmtOnCompile := true,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -57,9 +57,9 @@ object Dependencies {
   val Elastic4sClientEsJava      = "com.sksamuel.elastic4s"     %% "elastic4s-client-esjava"      % Versions.Elastic4s
   val Elastic4sCore              = "com.sksamuel.elastic4s"     %% "elastic4s-core"               % Versions.Elastic4s
   val Elastic4sTestkit           = "com.sksamuel.elastic4s"     %% "elastic4s-testkit"            % Versions.Elastic4s
-  val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % "7.10.2"
+  val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % "7.17.9"
   val ElasticsearchClusterRunner = "org.codelibs"                % "elasticsearch-cluster-runner" % "7.10.2.0"
-  val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % "7.10.2"
+  val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % "7.17.9"
   val FastMd5                    = "com.joyent.util"             % "fast-md5"                     % Versions.FastMd5
   val JodaTime                   = "joda-time"                   % "joda-time"                    % Versions.JodaTime
   val JUnit                      = "junit"                       % "junit"                        % Versions.JUnit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val Circe                   = "0.14.4"
     val CommonsCodec            = "1.15"
     val ConcurrentLinkedHashMap = "1.4.2"
-    val Elastic4s               = "7.10.10"
+    val Elastic4s               = "7.17.4"
     val FastMd5                 = "2.7.1"
     val JodaTime                = "2.12.2"
     val JUnit                   = "4.13.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val Elastic4sCore              = "com.sksamuel.elastic4s"     %% "elastic4s-core"               % Versions.Elastic4s
   val Elastic4sTestkit           = "com.sksamuel.elastic4s"     %% "elastic4s-testkit"            % Versions.Elastic4s
   val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % "7.17.9"
-  val ElasticsearchClusterRunner = "org.codelibs"                % "elasticsearch-cluster-runner" % "7.10.2.0"
+  val ElasticsearchClusterRunner = "org.codelibs"                % "elasticsearch-cluster-runner" % "7.17.1.0"
   val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % "7.17.9"
   val FastMd5                    = "com.joyent.util"             % "fast-md5"                     % Versions.FastMd5
   val JodaTime                   = "joda-time"                   % "joda-time"                    % Versions.JodaTime

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies {
     val CommonsCodec            = "1.15"
     val ConcurrentLinkedHashMap = "1.4.2"
     val Elastic4s               = "7.17.4"
+    val Elasticsearch           = "7.17.9"
     val FastMd5                 = "2.7.1"
     val JodaTime                = "2.12.2"
     val JUnit                   = "4.13.2"
@@ -57,9 +58,9 @@ object Dependencies {
   val Elastic4sClientEsJava      = "com.sksamuel.elastic4s"     %% "elastic4s-client-esjava"      % Versions.Elastic4s
   val Elastic4sCore              = "com.sksamuel.elastic4s"     %% "elastic4s-core"               % Versions.Elastic4s
   val Elastic4sTestkit           = "com.sksamuel.elastic4s"     %% "elastic4s-testkit"            % Versions.Elastic4s
-  val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % "7.17.9"
+  val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % Versions.Elasticsearch
   val ElasticsearchClusterRunner = "org.codelibs"                % "elasticsearch-cluster-runner" % "7.17.1.0"
-  val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % "7.17.9"
+  val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % Versions.Elasticsearch
   val FastMd5                    = "com.joyent.util"             % "fast-md5"                     % Versions.FastMd5
   val JodaTime                   = "joda-time"                   % "joda-time"                    % Versions.JodaTime
   val JUnit                      = "junit"                       % "junit"                        % Versions.JUnit


### PR DESCRIPTION
Migrating to the latest `elasticsearch` version within the major `v7.x.x` version.

### Testing

Relying on our `apso-elasticsearch` test specs:

```
sbt:apso> elasticsearch/test

[...]

[info] Passed: Total 5, Failed 0, Errors 0, Passed 5
[success] Total time: 28 s, completed Feb 22, 2023 2:03:45 PM
```