### PR TITLE
Remove unused elasticsearch dependency

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,6 @@ object Dependencies {
   val Elastic4sClientEsJava      = "com.sksamuel.elastic4s"     %% "elastic4s-client-esjava"      % Versions.Elastic4s
   val Elastic4sCore              = "com.sksamuel.elastic4s"     %% "elastic4s-core"               % Versions.Elastic4s
   val Elastic4sTestkit           = "com.sksamuel.elastic4s"     %% "elastic4s-testkit"            % Versions.Elastic4s
-  val Elasticsearch              = "org.elasticsearch"           % "elasticsearch"                % Versions.Elasticsearch
   val ElasticsearchClusterRunner = "org.codelibs"                % "elasticsearch-cluster-runner" % "7.17.1.0"
   val ElasticsearchRestClient    = "org.elasticsearch.client"    % "elasticsearch-rest-client"    % Versions.Elasticsearch
   val FastMd5                    = "com.joyent.util"             % "fast-md5"                     % Versions.FastMd5

--- a/testkit/build.sbt
+++ b/testkit/build.sbt
@@ -4,7 +4,6 @@ libraryDependencies ++= Seq(
   Elastic4sClientEsJava,
   Elastic4sCore,
   Elastic4sTestkit,
-  Elasticsearch,
   ElasticsearchClusterRunner,
   ScalaTestCore,
   Specs2Common  % Provided,


### PR DESCRIPTION
Title is self-explanatory.

Validated this was fine by running the full test suite. Seems like the `org.elasticsearch:elasticsearch` dependency was completely unused!