### PR TITLE
Add `SFTP` file descriptor credentials

### DIFF
--- a/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
+++ b/io/src/main/scala/com/velocidi/apso/io/SftpFileDescriptor.scala
@@ -239,6 +239,8 @@ object SftpFileDescriptor {
       ssh.disconnect()
     }
   }
+  
+  case class SftpFileDescriptorCredentials(host: String, port: String, auth: Either[Identity, String])
 
   implicit def sftpClientToSFTPClient(c: SftpClient): SFTPClient = c.sftpClient
 


### PR DESCRIPTION
It's a bit awkward to work with these `(String, String, Either[...])` tuples from a consumer perspective. Adding a case class around it!