### PR TITLE
Enhance `Retry` API

### DIFF
--- a/core/src/main/scala/com/velocidi/apso/Retry.scala
+++ b/core/src/main/scala/com/velocidi/apso/Retry.scala
@@ -31,7 +31,7 @@ object Retry {
       case 0 => Try(f)
       case _ =>
         Try(f) match {
-          case res@Success(_) => res
+          case res @ Success(_) => res
           case Failure(_) =>
             inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
             retry[T](maxRetries - 1, inBetweenSleep)(f)

--- a/core/src/main/scala/com/velocidi/apso/Retry.scala
+++ b/core/src/main/scala/com/velocidi/apso/Retry.scala
@@ -9,7 +9,9 @@ import scala.util.{Failure, Success, Try}
   */
 object Retry {
 
-  private[this] final def retryFuture[T](maxRetries: Int, inBetweenSleep: Option[FiniteDuration])(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+  private[this] final def retryFuture[T](maxRetries: Int, inBetweenSleep: Option[FiniteDuration])(
+      f: => Future[T]
+  )(implicit ec: ExecutionContext): Future[T] = {
     maxRetries match {
       case 0 =>
         f

--- a/core/src/main/scala/com/velocidi/apso/Retry.scala
+++ b/core/src/main/scala/com/velocidi/apso/Retry.scala
@@ -26,6 +26,19 @@ object Retry {
     }
   }
 
+  private[this] final def retry[T](maxRetries: Int, inBetweenSleep: Option[FiniteDuration])(f: => T): Try[T] = {
+    maxRetries match {
+      case 0 => Try(f)
+      case _ =>
+        Try(f) match {
+          case res@Success(_) => res
+          case Failure(_) =>
+            inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
+            retry[T](maxRetries - 1, inBetweenSleep)(f)
+        }
+    }
+  }
+
   /** Tries to perform a Future[T] until it succeeds or until maximum retries is reached.
     *
     * @param maxRetries
@@ -44,19 +57,6 @@ object Retry {
   def retryFuture[T](maxRetries: Int = 10, inBetweenSleep: FiniteDuration = 100.millis)(
       f: => Future[T]
   )(implicit ec: ExecutionContext): Future[T] = retryFuture(maxRetries, Option(inBetweenSleep))(f)
-
-  private[this] final def retry[T](maxRetries: Int, inBetweenSleep: Option[FiniteDuration])(f: => T): Try[T] = {
-    maxRetries match {
-      case 0 => Try(f)
-      case _ =>
-        Try(f) match {
-          case res @ Success(_) => res
-          case Failure(_) =>
-            inBetweenSleep.foreach(d => Thread.sleep(d.toMillis))
-            retry[T](maxRetries - 1, inBetweenSleep)(f)
-        }
-    }
-  }
 
   /** Tries to perform a function `f` until it succeeds or until maximum retries is reached.
     *


### PR DESCRIPTION
From a consumer perspective, it's not super nice to have to provide an override for the default `inBetweenSleep` timeout as an optional:

```scala
Retry.retry(5, Some(2.seconds))(foo)
```

With this refactor, you can simplify pass the timeout override as a regular duration. All the following are valid invocation signatures:

```scala
Retry.retry()(foo)

Retry.retry(25)(foo)

Retry.retry(25, 2.seconds)(foo)

Retry.retry(inBetweenSleep = 2.seconds)(foo)
```