### PR TITLE
Pin elasticsearch-cluster-runner version for Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,7 @@ updates {
 
   pin = [
     { groupId = "com.sksamuel.elastic4s", version = "7.16." },
+    { groupId = "org.codelibs", artifactId = "elasticsearch-cluster-runner", version = "7.16." },
     { groupId = "org.elasticsearch", artifactId = "elasticsearch", version = "7.16." },
     { groupId = "org.elasticsearch.client", artifactId = "elasticsearch-rest-client", version = "7.16." }
   ]


### PR DESCRIPTION
We need to pin elasticsearch-cluster-runner to the same version we pin the rest of Elasticsearch-related libraries.