### PR TITLE
Make the `Decoder` for `Currency` case insensitive

### DIFF
--- a/circe/src/main/scala/com/velocidi/apso/circe/ExtraJsonProtocol.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/ExtraJsonProtocol.scala
@@ -77,7 +77,7 @@ trait ExtraMiscJsonProtocol {
     Decoder[Json].emapPrettyTry(json => Try(ConfigFactory.parseString(json.toString)))
 
   implicit def currencyDecoder(implicit moneyContext: MoneyContext): Decoder[Currency] =
-    Decoder[String].emapPrettyTry(Currency(_))
+    Decoder[String].emapPrettyTry(s => Currency(s.toUpperCase))
   implicit val currencyEncoder: Encoder[Currency] = Encoder[String].contramap(_.toString)
 
   /** Encodes a map as an array of key-value objects.

--- a/circe/src/test/scala/com/velocidi/apso/circe/ExtraJsonProtocolSpec.scala
+++ b/circe/src/test/scala/com/velocidi/apso/circe/ExtraJsonProtocolSpec.scala
@@ -106,12 +106,12 @@ class ExtraJsonProtocolSpec extends Specification {
 
     "provide an Encoder and Decoder for Currency" in {
       implicit val moneyContext: MoneyContext = MoneyContext(EUR, defaultCurrencySet, Nil)
-      val currency: Currency = USD
-      val currencyString = """"USD""""
+      val usd: Currency = USD
 
-      currency.asJson.noSpaces mustEqual currencyString
-      decode[Currency](currencyString) must beRight(currency)
-      decode[Currency]("EU") must beLeft
+      usd.asJson.noSpaces mustEqual "\"USD\""
+      decode[Currency]("\"USD\"") must beRight(usd)
+      decode[Currency]("\"usd\"") must beRight(usd)
+      decode[Currency]("\"EU\"") must beLeft
     }
 
     "provide an Encoder and Decoder for a Map as an array of json objects" in {


### PR DESCRIPTION
This pull request makes the `Decoder` for `Currency` case insensitive by always attempting to capitalize the decoded string. Using uppercase codes aligns with ISO 4217 and with what [Squants](https://github.com/typelevel/squants) provides as default currencies.