### PR TITLE
Remove explicit dependency on the `organize-imports` Scalafix rule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ lazy val commonSettings = Seq(
 
   scalafmtOnCompile := true,
 
-  // Enable Scalafix and the OrganizeImports rule.
+  // Enable Scalafix.
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,
   scalafixOnCompile := true,
@@ -147,9 +147,6 @@ lazy val commonSettings = Seq(
   )
   // format: on
 )
-
-// Enable the OrganizeImports Scalafix rule.
-ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
 releaseCrossBuild    := true
 releaseTagComment    := s"Release ${(ThisBuild / version).value}"


### PR DESCRIPTION
This is a follow-up to #483. Since [Scalafix 0.11.0](https://github.com/scalacenter/scalafix/releases/tag/v0.11.0), `OrganizeImports` is a built-in rule.