### PR TITLE
Don't fail fast in CI matrix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         scala: ['2.12', '2.13']
         include:


### PR DESCRIPTION
Lets the build of each Scala version run to its full extent, even if the other one fails.