### PR TITLE
Rename `Velocidi` references to `Kevel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="https://raw.githubusercontent.com/velocidi/apso/master/apso.png"/></p>
+<p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
 # Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.adzerk/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.adzerk/apso_2.12)
 
@@ -760,7 +760,7 @@ js1.deleteField("a")
 js1.deleteField("d.f")
 // res62: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
-//
+//   
 // }]
 // )
 js1.deleteField("x")

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center"><img src="https://raw.githubusercontent.com/velocidi/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/velocidi/apso/workflows/CI/badge.svg?branch=master)](https://github.com/velocidi/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.adzerk/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.adzerk/apso_2.12)
 
-Apso is Velocidi's collection of Scala utility libraries. It provides a series of useful methods.
+Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
 ## Installation
 
@@ -760,7 +760,7 @@ js1.deleteField("a")
 js1.deleteField("d.f")
 // res62: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
-//   
+//
 // }]
 // )
 js1.deleteField("x")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.adzerk/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.adzerk/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Reporting Security Issues
 
-At Velocidi we take security bugs very seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+At Kevel we take security bugs very seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please email [engineering@velocidi.com](mailto:engineering@velocidi.com).
+To report a security issue, please email [audience-engineering@kevel.com](mailto:audience-engineering@kevel.com).

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val docs = (project in file("apso-docs"))
 
 lazy val commonSettings = Seq(
   // format: off
-  resolvers ++= 
+  resolvers ++=
     Resolver.sonatypeOssRepos("snapshots") ++
       Seq(
         Resolver.typesafeRepo("snapshots"),
@@ -135,11 +135,11 @@ lazy val commonSettings = Seq(
   pomIncludeRepository := { _ => false },
 
   licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-  homepage := Some(url("https://github.com/velocidi/apso")),
+  homepage := Some(url("https://github.com/adzerk/apso")),
   scmInfo := Some(
     ScmInfo(
-      url("https://github.com/velocidi/apso"),
-      "scm:git@github.com:velocidi/apso.git"
+      url("https://github.com/adzerk/apso"),
+      "scm:git@github.com:adzerk/apso.git"
     )
   )
   // format: on

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val docs = (project in file("apso-docs"))
 
 lazy val commonSettings = Seq(
   // format: off
-  resolvers ++=
+  resolvers ++= 
     Resolver.sonatypeOssRepos("snapshots") ++
       Seq(
         Resolver.typesafeRepo("snapshots"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-<p align="center"><img src="https://raw.githubusercontent.com/velocidi/apso/master/apso.png"/></p>
+<p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/velocidi/apso/workflows/CI/badge.svg?branch=master)](https://github.com/velocidi/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.adzerk/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.adzerk/apso_2.12)
 
-Apso is Velocidi's collection of Scala utility libraries. It provides a series of useful methods.
+Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.adzerk/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.adzerk/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 


### PR DESCRIPTION
Just renaming the public-facing documentation text references.

We should probably eventually also rename the package names from `velocidi` to `kevel`.

### Does this change relate to existing issues or pull requests?

Closes https://github.com/adzerk/apso/issues/553.

### Does this change require an update to the documentation?

This is an updated to the documentation!

### How has this been tested?

Tested hyperlinks to GitHub badges / hosted images after the `velocidi` -> `adzerk` organization update.
