### PR TITLE
Start using Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: adopt
-          java-version: 8
+          java-version: 11
 
       - name: Cache sbt
         uses: coursier/cache-action@v6

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -36,5 +36,5 @@ version will be published in [Sonatype's snapshots repository, under the Velocid
 To release the artifacts in the Sonatype's release repository, which eventually gets synced to
 [Maven Central](https://repo1.maven.org/maven2/com/velocidi/), simply use `sbt` to run `release`.
 
-This will result in the releasing of all the `apso-*` libraries. Please ensure you are using `java 8` when releasing
+This will result in the releasing of all the `apso-*` libraries. Please ensure you are using Java 11 when releasing
 new versions.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The `Geo` object provides methods to compute distances in kilometers between two
 import com.velocidi.apso.Geo
 
 Geo.distance((41.1617609, -8.6024716), (41.1763745, -8.5964861))
-// res2: Double = 1.7004440762344684
+// res2: Double = 1.7004440788845807
 ```
 
 You can also have the distance function curried if you are computing distances from a fixed point:
@@ -122,7 +122,7 @@ val distFromOffice = Geo.distanceFrom((41.1617609, -8.6024716))
 ```
 ```scala
 distFromOffice((41.1763745, -8.5964861))
-// res3: Double = 1.7004440762344684
+// res3: Double = 1.7004440788845807
 
 distFromOffice((38.7223032, -9.1414664))
 // res4: Double = 275.118392477037


### PR DESCRIPTION
Updates base Java version to the next LTS after 8 due to the introduction of a dependency that requires Java 11 in #583.

There was a small change in the docs output due to this update.

### Does this change relate to existing issues or pull requests?

* Follow-up to #583.

### Does this change require an update to the documentation?

The process instructions were updated accordingly.

### How has this been tested?

I ran the full test suite against this Java version.