### PR TITLE
Fix compilation for Java 19+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,31 +25,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup up JDK (Java 11)
-        id: setup-java-11
-        if: matrix.java == '11'
+      - name: Setup up JDK
         uses: actions/setup-java@v4
         with:
           distribution: adopt
-          java-version: 11
-          cache: sbt
-
-      - name: Setup up JDK (Java 17)
-        id: setup-java-17
-        if: matrix.java == '17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: adopt
-          java-version: 17
-          cache: sbt
-
-      - name: Setup up JDK (Java 21)
-        id: setup-java-21
-        if: matrix.java == '21'
-        uses: actions/setup-java@v4
-        with:
-          distribution: adopt
-          java-version: 21
+          java-version: ${{ matrix.java }}
           cache: sbt
 
       - name: Cache sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,14 @@ env:
 
 jobs:
   build:
-    name: Scala ${{ matrix.scala }}
+    name: Scala ${{ matrix.scala }} (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scala: ['2.12', '2.13']
+        java: ['11', '17', '21']
         include:
           - scala: '2.12'
             scala-version: 2.12.18
@@ -24,11 +25,32 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
+      - name: Setup up JDK (Java 11)
+        id: setup-java-11
+        if: matrix.java == '11'
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 11
+          cache: sbt
+
+      - name: Setup up JDK (Java 17)
+        id: setup-java-17
+        if: matrix.java == '17'
+        uses: actions/setup-java@v4
+        with:
+          distribution: adopt
+          java-version: 17
+          cache: sbt
+
+      - name: Setup up JDK (Java 21)
+        id: setup-java-21
+        if: matrix.java == '21'
+        uses: actions/setup-java@v4
+        with:
+          distribution: adopt
+          java-version: 21
+          cache: sbt
 
       - name: Cache sbt
         uses: coursier/cache-action@v6

--- a/akka-http/src/main/scala/com/velocidi/apso/akka/http/ExtraMiscDirectives.scala
+++ b/akka-http/src/main/scala/com/velocidi/apso/akka/http/ExtraMiscDirectives.scala
@@ -1,6 +1,6 @@
 package com.velocidi.apso.akka.http
 
-import java.net.URL
+import java.net.URI
 
 import scala.concurrent.duration._
 import scala.util.Try
@@ -40,7 +40,7 @@ trait ExtraMiscDirectives {
     */
   def optionalRefererHost: Directive1[Option[String]] =
     optionalHeaderValueByName("referer")
-      .map(_.flatMap(r => Try(new URL(r)).toOption.map(_.getHost)))
+      .map(_.flatMap(r => Try(new URI(r)).toOption.map(_.getHost)))
 }
 
 object ExtraMiscDirectives extends ExtraMiscDirectives

--- a/core/src/main/scala/com/velocidi/apso/config/LazyConfigFactory.scala
+++ b/core/src/main/scala/com/velocidi/apso/config/LazyConfigFactory.scala
@@ -1,7 +1,7 @@
 package com.velocidi.apso.config
 
 import java.io.File
-import java.net.{MalformedURLException, URL}
+import java.net.{MalformedURLException, URI}
 
 import com.typesafe.config._
 import com.typesafe.config.impl.Parseable
@@ -66,7 +66,7 @@ object LazyConfigFactory {
         ConfigFactory.parseFile(new File(file), overrideOptions)
       } else {
         try {
-          ConfigFactory.parseURL(new URL(url), overrideOptions)
+          ConfigFactory.parseURL(new URI(url).toURL, overrideOptions)
         } catch {
           case e: MalformedURLException =>
             throw new ConfigException.Generic(

--- a/profiling/src/main/scala/com/velocidi/apso/profiling/CpuSampler.scala
+++ b/profiling/src/main/scala/com/velocidi/apso/profiling/CpuSampler.scala
@@ -2,6 +2,7 @@ package com.velocidi.apso.profiling
 
 import java.lang.management.ManagementFactory
 
+import scala.annotation.nowarn
 import scala.collection.mutable
 
 import com.typesafe.scalalogging.Logger
@@ -44,7 +45,10 @@ class CpuSampler(samplePeriod: Long = 100, flushPeriod: Long = 10000, logger: Lo
 
   /** Captures the current call stacks of all live threads and stores relevant profiling data about them.
     */
+  @nowarn("cat=deprecation")
   def sample() = for {
+    // TODO Thread#getId is deprecated as of Java 19 and should be replaced with Thread#threadId.
+    // Unfortunately, this is only available since Java 19.
     info <- threadBean.dumpAllThreads(false, false) if info.getThreadId != Thread.currentThread.getId
     elem <- info.getStackTrace.headOption if shouldProfile(elem)
   } entries.enqueue(elem)


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

Addresses the following (fatal) deprecation warnings, which made it so that Apso would not compile on Java 19 and above.
- Java 19 deprecated [`Thread#getId`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#getId()) in favor of the new [`Thread#threadId()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#threadId()).
- Java 20 deprecated the `URL` constructor in favor of `new URI(...).toURL` (See https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#constructor-deprecation).

### Does this change relate to existing issues or pull requests?

No

### Does this change require an update to the documentation?

No

### How has this been tested?

By compiling the whole project using OpenJDK 21.0.2 and running the unit tests.
