### PR TITLE
Small improvement to JsonConvert performance

### DIFF
--- a/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
@@ -3,8 +3,8 @@ package com.velocidi.apso.circe
 import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 
-import io.circe.Json
 import io.circe.syntax._
+import io.circe.{Json, JsonObject}
 
 /** Object containing helpers for converting between JSON values and other structures.
   */
@@ -17,16 +17,17 @@ object JsonConvert {
     *   the given object converted to a [[io.circe.Json]] value.
     */
   def toJson(obj: Any): Json = obj match {
-    case null           => Json.Null
-    case n: Int         => n.asJson
-    case n: Long        => n.asJson
-    case n: Double      => n.asJson
-    case b: Boolean     => b.asJson
-    case str: String    => str.asJson
-    case map: Map[_, _] => Json.obj(map.map { case (k, v) => (k.toString, toJson(v)) }.toList: _*)
+    case null        => Json.Null
+    case n: Int      => n.asJson
+    case n: Long     => n.asJson
+    case n: Double   => n.asJson
+    case b: Boolean  => b.asJson
+    case str: String => str.asJson
+    case map: Map[_, _] =>
+      Json.fromJsonObject(JsonObject.fromMap(map.map { case (k, v) => (k.toString, toJson(v)) }))
     case map: java.util.Map[_, _] =>
       Json.obj(map.asScala.map({ case (k, v) => (k.toString, toJson(v)) }).toList: _*)
-    case t: IterableOnce[_]       => Json.fromValues(t.iterator.map(toJson).to(Vector))
+    case t: IterableOnce[_]       => Json.fromValues(t.iterator.map(toJson).toVector)
     case t: java.lang.Iterable[_] => Json.fromValues(t.asScala.map(toJson).toVector)
     case arr: Array[_]            => Json.fromValues(arr.toVector.map(toJson))
     case _                        => Json.fromString(obj.toString)


### PR DESCRIPTION
Build a `Json` from a `JsonObject` when converting from a map. The internal data structure used is different and seems to be slightly more performant.

```
Benchmark        Mode  Cnt      Score     Error  Units
Bench.newBench  thrpt    5  11937.246 ± 213.424  ops/s
Bench.oldBench  thrpt    5  10711.585 ± 347.067  ops/s
```

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

Running the test suite
