### PR TITLE
Improvement to JsonConvert performance 2.0

### DIFF
--- a/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
+++ b/circe/src/main/scala/com/velocidi/apso/circe/JsonConvert.scala
@@ -24,7 +24,9 @@ object JsonConvert {
     case b: Boolean  => b.asJson
     case str: String => str.asJson
     case map: Map[_, _] =>
-      Json.fromJsonObject(JsonObject.fromMap(map.map { case (k, v) => (k.toString, toJson(v)) }))
+      Json.fromJsonObject(
+        JsonObject.fromIterable(map.iterator.map { case (k, v) => (k.toString, toJson(v)) }.to(Iterable))
+      )
     case map: java.util.Map[_, _] =>
       Json.obj(map.asScala.map({ case (k, v) => (k.toString, toJson(v)) }).toList: _*)
     case t: IterableOnce[_]       => Json.fromValues(t.iterator.map(toJson).toVector)


### PR DESCRIPTION
Follow-up on https://github.com/adzerk/apso/pull/612

```
[info] Benchmark        Mode  Cnt      Score      Error  Units
[info] Bench.newBench  thrpt    4  18527.404 ± 2858.114  ops/s
[info] Bench.oldBench  thrpt    4  10850.526 ±  433.352  ops/s
```

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

CI
