### PR TITLE
Ensure that all classes are compiled with Java 11 bytecode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ ThisBuild / organization := "com.velocidi"
 
 ThisBuild / crossScalaVersions := Seq("2.12.18", "2.13.12")
 ThisBuild / scalaVersion       := "2.13.12"
-val javaVersion                 = "11"
+val javaVersion = "11"
 
 // Workaround for incompatible scala-xml versions taken from https://github.com/scala/bug/issues/12632. scala-xml 1.x
 // and scala-xml 2.x are "mostly" binary compatible.

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ ThisBuild / organization := "com.velocidi"
 
 ThisBuild / crossScalaVersions := Seq("2.12.18", "2.13.12")
 ThisBuild / scalaVersion       := "2.13.12"
+val javaVersion                 = "11"
 
 // Workaround for incompatible scala-xml versions taken from https://github.com/scala/bug/issues/12632. scala-xml 1.x
 // and scala-xml 2.x are "mostly" binary compatible.
@@ -118,6 +119,7 @@ lazy val commonSettings = Seq(
       "-feature",
       "-unchecked",
       "-deprecation",
+      "-release", javaVersion,
       "-Xfatal-warnings",
       "-Ywarn-dead-code")
 
@@ -134,6 +136,10 @@ lazy val commonSettings = Seq(
           "-Ywarn-unused:imports")
     }
   },
+
+  javacOptions ++= List(
+    "--release", javaVersion
+  ),
 
   autoAPIMappings := true,
 


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

Ensures that all classes are compiled to the same Java bytecode version (in this case, version 55, for Java 11).

Previously Scala code was using version 52 (Java 8) and Java code was using the version from the installed JDK.

### Does this change relate to existing issues or pull requests?

No

### Does this change require an update to the documentation?

No.

### How has this been tested?

To test this, we use `com.velocidi.apso.hashing.MurmurHash3` (which is generated from a `.java` file) and `com.velocidi.apso.hashing.Implicits` (which is generated from a `.scala` file)

Using Java 21, previously when compiling Apso we would get:

```
$ javap -verbose hashing/target/scala-2.13/classes/com/velocidi/apso/hashing/MurmurHash3.class | grep version
  minor version: 0
  major version: 65
$ javap -verbose hashing/target/scala-2.13/classes/com/velocidi/apso/hashing/Implicits.class | grep version
  minor version: 0
  major version: 52
```

After the changes, we get:
```
$ javap -verbose hashing/target/scala-2.13/classes/com/velocidi/apso/hashing/MurmurHash3.class | grep version
  minor version: 0
  major version: 55
$ javap -verbose hashing/target/scala-2.13/classes/com/velocidi/apso/hashing/Implicits.class | grep version
  minor version: 0
  major version: 55
```
