### PR TITLE
Add `utcLocalDateTime` to `ApsoTimeDateTime`

### DIFF
--- a/time/src/main/scala/com/velocidi/apso/time/Implicits.scala
+++ b/time/src/main/scala/com/velocidi/apso/time/Implicits.scala
@@ -66,6 +66,12 @@ object Implicits {
     */
   final implicit class ApsoTimeDateTime(val d1: DateTime) extends AnyVal {
 
+    /** Returns a `LocalDateTime` corresponding to this `DateTime` at UTC.
+      * @return
+      *   a `LocalDateTime` corresponding to this `DateTime` at UTC.
+      */
+    def utcLocalDateTime: LocalDateTime = d1.withZone(DateTimeZone.UTC).toLocalDateTime
+
     /** Returns a `LocalDate` corresponding to this `DateTime` at UTC.
       * @return
       *   a `LocalDate` corresponding to this `DateTime` at UTC.

--- a/time/src/test/scala/com/velocidi/apso/time/ImplicitsSpec.scala
+++ b/time/src/test/scala/com/velocidi/apso/time/ImplicitsSpec.scala
@@ -47,6 +47,16 @@ class ImplicitsSpec extends Specification {
 
   "An ApsoTimeDateTime" should {
 
+    "support conversion to UTC LocalDateTime" in {
+      val localDateTime = LocalDateTime.parse("2014-01-01T01:10:58")
+      val dateTime = localDateTime.toDateTime(DateTimeZone.forID("NZ"))
+      val estLocalDateTime = dateTime.toLocalDateTime
+      val utcLocalDateTime = dateTime.utcLocalDateTime
+
+      estLocalDateTime === new LocalDateTime(2014, 1, 1, 1, 10, 58)
+      utcLocalDateTime === new LocalDateTime(2013, 12, 31, 12, 10, 58)
+    }
+
     "support conversion to UTC LocalDate" in {
       val localDate = "2014-01-01".toLocalDate
       val dateTime = localDate.toDateTimeAtStartOfDay.toDateTime(DateTimeZone.forID("EST"))


### PR DESCRIPTION
Adds a `utcLocalDateTime` method to `ApsoTimeDateTime`.

<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

### Does this change relate to existing issues or pull requests?

NA

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

No

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Added an example to `ImplicitsSpec`.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
