### PR TITLE
Update nodejs version used in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18.18.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup up JDK
         uses: actions/setup-java@v4
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts'
+          node-version: 'lts/*'
 
       - name: Validate Changelog formatting
         run: npx zx --install .github/workflows/scripts/validate_changelog.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18.18.0'
+          node-version: 'lts'
 
       - name: Validate Changelog formatting
         run: npx zx --install .github/workflows/scripts/validate_changelog.mjs


### PR DESCRIPTION
We are using github actions versions that, underlying, are using NodeJS 16 (which is mark for deprecation!).
We should bump their versions to the ones using NodeJS 20.

### Does this change require an update to the documentation?

No.

### Can this PR be safely merged to the target branch after approval?

Yes.

### How has this been tested?

Relying on CI.
