### PR TITLE
Force eviction of jackson-databind 2.13.1

### DIFF
--- a/elasticsearch/build.sbt
+++ b/elasticsearch/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  AkkaActor                  % Provided,
+  AkkaActor                    % Provided,
   ApacheHttpAsyncClient,
   ApacheHttpClient,
   ApacheHttpCore,
@@ -9,12 +9,15 @@ libraryDependencies ++= Seq(
   Elastic4sClientEsJava,
   Elastic4sCore,
   ElasticsearchRestClient,
-  AkkaTestkit                % Test,
-  AkkaHttpTestkit            % Test,
-  AkkaSlf4J                  % Test,
-  Elastic4sTestkit           % Test,
-  ElasticsearchClusterRunner % Test,
-  Log4JCore                  % Test,
-  Log4JSlf4j                 % Test,
-  Specs2Core                 % Test
+  // This is explicitly included to force the eviction of a dependency exposing the following direct vulnerabilities:
+  // CVE-2022-42004, CVE-2022-42003 and CVE-2020-36518.
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
+  AkkaTestkit                  % Test,
+  AkkaHttpTestkit              % Test,
+  AkkaSlf4J                    % Test,
+  Elastic4sTestkit             % Test,
+  ElasticsearchClusterRunner   % Test,
+  Log4JCore                    % Test,
+  Log4JSlf4j                   % Test,
+  Specs2Core                   % Test
 )


### PR DESCRIPTION
Following Jackson's [version conventions](https://github.com/FasterXML/jackson/wiki/Jackson-Releases#general), patch versions should be binary compatible, and jackson-databind 2.13.5 doesn't expose the CVE-2022-42004, CVE-2022-42003 and CVE-2020-36518 vulnerabilities.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I'm relying on existing unit tests. I also verified that jackson-databind 2.13.1 was correctly being evicted using `whatDependsOn com.fasterxml.jackson.core jackson-databind 2.13.1` in sbt.