### PR TITLE
Force eviction of jackson-databind 2.13.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,6 +10,9 @@ updates {
   ]
 
   pin = [
+    # We want to have jackson-databind at a version that is binary compatible with the one elastic4s uses but that
+    # doesn't expose known vulnerabilities.
+    { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.13.5" },
     { groupId = "com.sksamuel.elastic4s", version = "7.16." },
     { groupId = "org.codelibs", artifactId = "elasticsearch-cluster-runner", version = "7.16." },
     { groupId = "org.elasticsearch", artifactId = "elasticsearch", version = "7.16." },

--- a/elasticsearch-pekko/build.sbt
+++ b/elasticsearch-pekko/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  PekkoActor                 % Provided,
+  PekkoActor                   % Provided,
   ApacheHttpAsyncClient,
   ApacheHttpClient,
   ApacheHttpCore,
@@ -9,12 +9,15 @@ libraryDependencies ++= Seq(
   Elastic4sClientEsJava,
   Elastic4sCore,
   ElasticsearchRestClient,
-  PekkoTestkit               % Test,
-  PekkoHttpTestkit           % Test,
-  PekkoSlf4J                 % Test,
-  Elastic4sTestkit           % Test,
-  ElasticsearchClusterRunner % Test,
-  Log4JCore                  % Test,
-  Log4JSlf4j                 % Test,
-  Specs2Core                 % Test
+  // This is explicitly included to force the eviction of a dependency exposing the following direct vulnerabilities:
+  // CVE-2022-42004, CVE-2022-42003 and CVE-2020-36518.
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
+  PekkoTestkit                 % Test,
+  PekkoHttpTestkit             % Test,
+  PekkoSlf4J                   % Test,
+  Elastic4sTestkit             % Test,
+  ElasticsearchClusterRunner   % Test,
+  Log4JCore                    % Test,
+  Log4JSlf4j                   % Test,
+  Specs2Core                   % Test
 )

--- a/elasticsearch/build.sbt
+++ b/elasticsearch/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  AkkaActor                  % Provided,
+  AkkaActor                    % Provided,
   ApacheHttpAsyncClient,
   ApacheHttpClient,
   ApacheHttpCore,
@@ -9,12 +9,15 @@ libraryDependencies ++= Seq(
   Elastic4sClientEsJava,
   Elastic4sCore,
   ElasticsearchRestClient,
-  AkkaTestkit                % Test,
-  AkkaHttpTestkit            % Test,
-  AkkaSlf4J                  % Test,
-  Elastic4sTestkit           % Test,
-  ElasticsearchClusterRunner % Test,
-  Log4JCore                  % Test,
-  Log4JSlf4j                 % Test,
-  Specs2Core                 % Test
+  // This is explicitly included to force the eviction of a dependency exposing the following direct vulnerabilities:
+  // CVE-2022-42004, CVE-2022-42003 and CVE-2020-36518.
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.13.5",
+  AkkaTestkit                  % Test,
+  AkkaHttpTestkit              % Test,
+  AkkaSlf4J                    % Test,
+  Elastic4sTestkit             % Test,
+  ElasticsearchClusterRunner   % Test,
+  Log4JCore                    % Test,
+  Log4JSlf4j                   % Test,
+  Specs2Core                   % Test
 )


### PR DESCRIPTION
Following Jackson's [version conventions](https://github.com/FasterXML/jackson/wiki/Jackson-Releases#general), patch versions should be binary compatible, and jackson-databind 2.13.5 doesn't expose the CVE-2022-42004, CVE-2022-42003 and CVE-2020-36518 vulnerabilities.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I'm relying on existing unit tests. I also verified that jackson-databind 2.13.1 was correctly being evicted using `whatDependsOn com.fasterxml.jackson.core jackson-databind 2.13.1` in sbt.