### PR TITLE
Override `bcprov-jdk18on` transient dependency

### DIFF
--- a/io/build.sbt
+++ b/io/build.sbt
@@ -1,8 +1,12 @@
 import Dependencies._
 
 libraryDependencies ++= Seq(
-  AwsJavaSdkS3,
   AwsJavaSdkCore,
+  AwsJavaSdkS3,
+  // FIX: Explicitly override transient bouncy castle versions from `sshj`: https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984
+  // Remove once com.hierynomus:sshj releases a version with https://github.com/hierynomus/sshj/pull/938
+  BouncyCastlePkix,
+  BouncyCastleProvider,
   ScalaCollectionCompat,
   ScalaLogging,
   ScalaPool,


### PR DESCRIPTION
Addresses [IN1-JAVA-ORGBOUNCYCASTLE-6612984](https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984). 
This vulnerability was already addressed by ssh https://github.com/hierynomus/sshj/pull/938 but a new version is yet to be released.

### Does this change relate to existing issues or pull requests?
No.
<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?
No.
<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?
Relying on the existing CI.
```sbt:apso> whatDependsOn org.bouncycastle bcprov-jdk18on 1.75
[info] org.bouncycastle:bcprov-jdk18on:1.75 (evicted by: 1.78.1)
[info]   +-com.hierynomus:sshj:0.38.0
[info]     +-com.velocidi:apso-io_2.13:0.19.5-SNAPSHOT [S]
[info]
[info] org.bouncycastle:bcprov-jdk18on:1.75 (evicted by: 1.78.1)
[info]   +-com.hierynomus:sshj:0.38.0
[info]     +-com.velocidi:apso-io_2.13:0.19.5-SNAPSHOT [S]
[info]       +-com.velocidi:apso_2.13:0.19.5-SNAPSHOT [S]
```
<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
