### PR TITLE
Allow specifying `max-connections` on S3 client

### DIFF
--- a/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
+++ b/aws/src/main/scala/com/velocidi/apso/aws/S3Bucket.scala
@@ -36,6 +36,7 @@ class S3Bucket(
 
   private[this] lazy val configPrefix = "aws.s3"
   private[this] lazy val region = Try(config.getString(configPrefix + ".region"))
+  private[this] lazy val maxConnections = Try(config.getInt(configPrefix + ".max-connections"))
 
   @transient private[this] var _s3: AmazonS3 = _
 
@@ -43,6 +44,7 @@ class S3Bucket(
     if (_s3 == null) {
       val defaultConfig = new ClientConfiguration()
         .withTcpKeepAlive(true)
+        .withMaxConnections(maxConnections.getOrElse(ClientConfiguration.DEFAULT_MAX_CONNECTIONS))
 
       _s3 = AmazonS3ClientBuilder.standard
         .withCredentials(credentialsProvider())


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

As titled.

It's useful to be able to tweak this setting in scenarios where we are dealing with many concurrent connections.

### Does this change relate to existing issues or pull requests?

No.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

I don't think so. Or, at least, I couldn't find any mention to the existing `region` setting.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Ad-hoc testing locally.
I thought about creating unit tests to check that we are propagating this value correctly. However, all the relevant things are private and we already have specs for our ConfigLoader. We could think of a spec that checks that we are able to maintain more than X open connections, but I'm not sure if that's worth the hassle. 

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
