### PR TITLE
Fix race condition in LruCache when handling exceptions

### DIFF
--- a/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
@@ -73,9 +73,10 @@ final class SimpleLruCache[V](val maxCapacity: Int, val initialCapacity: Int) ex
       case null =>
         val future = genValue()
         future.onComplete { value =>
-          promise.complete(value)
           // in case of exceptions we remove the cache entry (i.e. try again later)
           if (value.isFailure) store.remove(key, promise.future)
+
+          promise.complete(value)
         }
         future
       case existingFuture => existingFuture

--- a/caching/src/test/scala/com/velocidi/apso/caching/ExpiringLruCacheSpec.scala
+++ b/caching/src/test/scala/com/velocidi/apso/caching/ExpiringLruCacheSpec.scala
@@ -85,8 +85,7 @@ class ExpiringLruCacheSpec(implicit ee: ExecutionEnv) extends Specification {
       cache(2)(Future.successful("B")) must beEqualTo("B").await
       cache(3)("C") must beEqualTo("C").await
       cache.store.toString === "{1=A, 2=B, 3=C}"
-      cache(4)("D")
-      Thread.sleep(10)
+      cache(4)("D") must beEqualTo("D").await
       cache.store.toString === "{2=B, 3=C, 4=D}"
       cache.size === 3
       cache.keys === Set(2, 3, 4)


### PR DESCRIPTION
Reorders the operations in the `LruCache` to avoid race conditions.

When the future failed, the other threads could still fetch the failed result before the cache entry was deleted (this can be simulated by adding a `blocking(Thread.sleep(1000))` between the instructions).

Now the cache entry is deleted first, leaving other threads free to create new futures, before marking the returned future as failed.

This was detected by flaky tests in https://github.com/adzerk/apso/pull/690/checks.

### Does this change relate to existing issues or pull requests?

No

### Does this change require an update to the documentation?

No

### How has this been tested?

Unit tests.

I also reproduced the previous issue by changing the code to:

```scala
promise.complete(value)
scala.concurrent.blocking(Thread.sleep(1000))
if (value.isFailure) store.remove(key, promise.future)
```

Doing the same thing with the new ordering does not cause any issue.