### PR TITLE
Fix `ValueMagnet` implicit conversion from `Any`

### DIFF
--- a/caching/src/main/scala/com/velocidi/apso/caching/Cache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/Cache.scala
@@ -20,6 +20,7 @@
 package com.velocidi.apso.caching
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /** General interface implemented by all spray cache implementations.
@@ -90,6 +91,6 @@ trait Cache[V] { cache =>
 
 class ValueMagnet[V](val future: Future[V])
 object ValueMagnet {
-  implicit def fromAny[V](block: V): ValueMagnet[V] = fromFuture(Future.successful(block))
+  implicit def fromAny[V](block: => V): ValueMagnet[V] = fromFuture(Future.fromTry(Try(block)))
   implicit def fromFuture[V](future: Future[V]): ValueMagnet[V] = new ValueMagnet(future)
 }

--- a/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
+++ b/caching/src/main/scala/com/velocidi/apso/caching/LruCache.scala
@@ -78,7 +78,7 @@ final class SimpleLruCache[V](val maxCapacity: Int, val initialCapacity: Int) ex
 
           promise.complete(value)
         }
-        future
+        promise.future
       case existingFuture => existingFuture
     }
   }


### PR DESCRIPTION
The block we convert into a `ValueMagnet` can throw, in which case we won't produce a ValueMagnet. I think we want to be safe and produce a `ValueMagnet` with a failed `Future` in those scenarios. There's a change this is what's causing flaky tests like [this one](https://github.com/adzerk/apso/actions/runs/9545009884/job/26304892600), because the exception being thrown in the implicit conversion might end up not being caught.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I made sure the tests continued to succeed locally. I couldn't deterministically reproduce the flaky test in my machine.