### PR TITLE
Remove the coursier/cache-action step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup up JDK
+        id: setup-java
         uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: ${{ matrix.java }}
           cache: sbt
 
-      - name: Cache sbt
-        uses: coursier/cache-action@v6
+      - name: Update dependencies
+        if: steps.setup-java.outputs.cache-hit == 'false'
+        run: sbt +update
 
       - name: Compile and check format
         run: >-


### PR DESCRIPTION
The coursier/cache-action step would unnecessarily create a proliferation of dependency caches (one for each build matrix combination times the `coursier` and `sbt-ivy2` prefix). We were already enabling caching of sbt dependencies in the setup-java action so I think that's enough. The only extra thing this adds is an explicit `sbt +update` so that the cache gets populated with the dependencies for all Scala versions.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I'm relying on a successful CI build.