### PR TITLE
Force empty line after top-level package statement

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,6 +2,9 @@ version = 3.8.3
 
 runner.dialect = scala213
 maxColumn = 120
+newlines.topLevelStatementBlankLines = [
+  { blanks: { after: 0 } }
+]
 fileOverride {
   "glob:**/*.sbt" {
     runner.dialect = sbt1


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

We try to always keep an empty line after the package statement at the top of the file, however we don't have this enforced by our scalafmt configuration files. This PR changes that in a hackish way given the following (as stated in [here](https://scalameta.org/scalafmt/docs/configuration.html#newlines-around-package-or-template-body)): 
> the rules do not directly apply to package statements at the top of the source file; however, if this parameter is non-empty, there will be at least one blank line before the first non-package statement, and possibly more if the rules match that statement

### Does this change relate to existing issues or pull requests?

No.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

No.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Tested locally by adding some empty lines in other places we want them and check that this does not remove them. Also ran a root `scalafixAll`.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
