### PR TITLE
Update the publishing namespace from `com.velocidi` to `com.kevel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ version of jackson-databind, which fixes CVE-2022-42004, CVE-2022-42003 and CVE-
 ### Changed
 - Minor dependency updates.
 
-[0.19.3]: https://github.com/velocidi/apso/compare/v0.19.2...v0.19.3
+[0.19.3]: https://github.com/adzerk/apso/compare/v0.19.2...v0.19.3
 
 ## [0.19.2] - 2024-02-20
 
@@ -162,7 +162,7 @@ It also fixes some issues with the retry logic when calling S3, where some error
 - Improvement to JsonConvert performance 2.0 ([#615](https://github.com/adzerk/apso/pull/615)).
 - Performance improvements converting Java Map to Json ([#622](https://github.com/adzerk/apso/pull/622)).
 
-[0.19.2]: https://github.com/velocidi/apso/compare/v0.19.1...v0.19.2
+[0.19.2]: https://github.com/adzerk/apso/compare/v0.19.1...v0.19.2
 
 ## [0.19.1] - 2023-11-30
 
@@ -174,7 +174,7 @@ The most notable dependency update is Unirest, to version 4.2.0, which solves co
 - Start using Java 11 ([#584](https://github.com/adzerk/apso/pull/584)).
 - Update other dependencies.
 
-[0.19.1]: https://github.com/velocidi/apso/compare/v0.19.0...v0.19.1
+[0.19.1]: https://github.com/adzerk/apso/compare/v0.19.0...v0.19.1
 
 ## [0.19.0] - 2023-10-07
 
@@ -207,7 +207,7 @@ Several dependencies were update to their latest versions. You can see all the d
 - Remove Elasticsearch TestKit ([#490](https://github.com/adzerk/apso/pull/490)).
 - Drop apso-log project ([#549](https://github.com/adzerk/apso/pull/549)).
 
-[0.19.0]: https://github.com/velocidi/apso/compare/v0.18.8...v0.19.0
+[0.19.0]: https://github.com/adzerk/apso/compare/v0.18.8...v0.19.0
 
 ## [0.18.8] - 2023-04-27
 
@@ -248,14 +248,14 @@ insensitive. This means that, for example, both `"usd"` and `"USD"` now decode t
 - Update aws-java-sdk-s3 to 1.12.457 ([#468](https://github.com/adzerk/apso/pull/468)).
 - Update scala-collection-compat to 2.10.0 ([#469](https://github.com/adzerk/apso/pull/469)).
 
-[0.18.8]: https://github.com/velocidi/apso/compare/v0.18.7...v0.18.8
+[0.18.8]: https://github.com/adzerk/apso/compare/v0.18.7...v0.18.8
 
 ## [0.18.7] - 2023-02-28
 
 ### Changed
 - Update elasticsearch-related dependencies to `7.16.x` ([#432](https://github.com/adzerk/apso/pull/432)).
 
-[0.18.7]: https://github.com/velocidi/apso/compare/v0.18.6...v0.18.7
+[0.18.7]: https://github.com/adzerk/apso/compare/v0.18.6...v0.18.7
 
 ## [0.18.6] - 2023-02-22
 
@@ -263,39 +263,39 @@ insensitive. This means that, for example, both `"usd"` and `"USD"` now decode t
 - Update elasticsearch-related dependencies to the most recent version within the `7.x.x` major version ([#427](https://github.com/adzerk/apso/pull/427)).
 - Other dependency updates.
 
-[0.18.6]: https://github.com/velocidi/apso/compare/v0.18.5...v0.18.6
+[0.18.6]: https://github.com/adzerk/apso/compare/v0.18.5...v0.18.6
 
 ## [0.18.4] - 2022-05-20
 
 ### Changed
-- Disable some Elasticsearch features on ElasticsearchTestKit ([#262](https://github.com/velocidi/apso/pull/262)).
-- Allow Elasticsearch base path to be overridden on ElasticsearchTestKit ([#263](https://github.com/velocidi/apso/pull/263)).
+- Disable some Elasticsearch features on ElasticsearchTestKit ([#262](https://github.com/adzerk/apso/pull/262)).
+- Allow Elasticsearch base path to be overridden on ElasticsearchTestKit ([#263](https://github.com/adzerk/apso/pull/263)).
 - Dependency updates.
 
-[0.18.4]: https://github.com/velocidi/apso/compare/v0.18.3...v0.18.4
+[0.18.4]: https://github.com/adzerk/apso/compare/v0.18.3...v0.18.4
 
 ## [0.18.3] - 2022-05-11
 
 This is a maintenance release, with only dependency updates.
 
-[0.18.3]: https://github.com/velocidi/apso/compare/v0.18.2...v0.18.3
+[0.18.3]: https://github.com/adzerk/apso/compare/v0.18.2...v0.18.3
 
 ## [0.18.2] - 2022-02-24
 
 ### Removed
-- Remove Log4j dependency from apso-log ([#153](https://github.com/velocidi/apso/pull/153)).
-- Remove TryWith in favor of scala 2.13 native resource management tools ([#187](https://github.com/velocidi/apso/pull/187)).
+- Remove Log4j dependency from apso-log ([#153](https://github.com/adzerk/apso/pull/153)).
+- Remove TryWith in favor of scala 2.13 native resource management tools ([#187](https://github.com/adzerk/apso/pull/187)).
 
-[0.18.2]: https://github.com/velocidi/apso/compare/v0.18.1...v0.18.2
+[0.18.2]: https://github.com/adzerk/apso/compare/v0.18.1...v0.18.2
 
 ## [0.18.1] - 2021-07-06
 
 This is the first version with a Changelog, albeit not being the first version of Apso.
 
 ### Changed
-- Update Scala, dependencies and plugins versions ([#142](https://github.com/velocidi/apso/pull/142)).
+- Update Scala, dependencies and plugins versions ([#142](https://github.com/adzerk/apso/pull/142)).
 
-[0.18.1]: https://github.com/velocidi/apso/compare/v0.18.0...v0.18.1
+[0.18.1]: https://github.com/adzerk/apso/compare/v0.18.0...v0.18.1
 
 ***
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ### Security
 -->
 
+## [0.20.0] - 2024-10-16
+
+This release is an exact copy of v0.19.7, but now published under the `com.kevel` namespace.
+
+[0.20.0]: https://github.com/adzerk/apso/compare/v0.19.7...v0.20.0
+
 ## [0.19.7] - 2024-10-16
 
 This release includes some bug fixes and dependency updates. It will also be last version of Apso published under the

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -26,15 +26,10 @@ following the template.
 
 It's recommended to open a PR with the Changelog changes so that they can be reviewed by someone else from the team.
 
-### Publishing a snapshot version
-
-To publish a snapshot version to [Nexus Sonatype](https://oss.sonatype.org), simply use `sbt` to run `+publish`. The
-version will be published in [Sonatype's snapshots repository, under the Velocidi organization](https://oss.sonatype.org/content/repositories/snapshots/com/velocidi/).
-
 ### Releasing artifacts
 
 To release the artifacts in the Sonatype's release repository, which eventually gets synced to
-[Maven Central](https://repo1.maven.org/maven2/com/velocidi/), simply use `sbt` to run `release`.
+[Maven Central](https://repo1.maven.org/maven2/com/kevel), simply use `sbt` to run `release`.
 
 This will result in the releasing of all the `apso-*` libraries. Please ensure you are using Java 11 when releasing
 new versions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.12)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
@@ -11,7 +11,7 @@ Apso's latest release is built against Scala 2.12 and Scala 2.13.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso" % "0.20.0"
 ```
 
 The project is divided in modules, you can instead install only a specific module.
@@ -19,7 +19,7 @@ The project is divided in modules, you can instead install only a specific modul
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-testkit" % "0.18.8" % "test"
+libraryDependencies += "com.kevel" %% "apso-testkit" % "0.20.0" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.
@@ -69,7 +69,7 @@ Please take into account that the library is still in an experimental stage and 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-core" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-core" % "0.20.0"
 ```
 
 ### Config
@@ -285,7 +285,7 @@ The same features are provided for Pekko under the `pekko-http` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-akka-http" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-akka-http" % "0.20.0"
 ```
 
 ### ClientIPDirectives
@@ -307,7 +307,7 @@ Apso provides a group of classes to ease the interaction with the Amazon Web Ser
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-aws" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-aws" % "0.20.0"
 ```
 
 ### ConfigCredentialsProvider
@@ -354,7 +354,7 @@ The `apso-caching` module provides provides utilities for caching.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-caching" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-caching" % "0.20.0"
 ```
 
 Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Guava` or `Caffeine` as underlying cache implementations.
@@ -408,7 +408,7 @@ y
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-collections" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-collections" % "0.20.0"
 ```
 
 ### Trie
@@ -609,7 +609,7 @@ creation of the underlying Cyphers.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-encryption" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-encryption" % "0.20.0"
 ```
 
 The following shows the creation of `Encryptor` and `Decryptor` objects,
@@ -634,7 +634,7 @@ decryptor.get.decryptToString(encryptor.get.encryptToSafeString(secretData).get)
 Apso provides utilities for various hashing functions. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-hashing" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-hashing" % "0.20.0"
 ```
 
 ```scala
@@ -654,7 +654,7 @@ Apso provides methods to deal with IO-related features in the `io` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-io" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-io" % "0.20.0"
 ```
 
 ### FileDescriptor
@@ -697,7 +697,7 @@ ResourceUtil.getResourceAsString("reference.conf")
 Apso includes a bunch of utilities to work with JSON serialization and deserialization, specifically with the [circe](https://circe.github.io/circe/) library. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-circe" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-circe" % "0.20.0"
 ```
 
 ### ExtraJsonProtocol
@@ -809,7 +809,7 @@ The `profiling` module of apso provides utilities to help with profiling the run
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-profiling" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-profiling" % "0.20.0"
 ```
 
 ### CpuSampler
@@ -827,7 +827,7 @@ The `apso-time` module provides utilities to work with `DateTime` and `LocalDate
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-time" % "0.18.8"
+libraryDependencies += "com.kevel" %% "apso-time" % "0.20.0"
 ```
 
 See the following sample usages:

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 import spray.boilerplate.BoilerplatePlugin
 import xerial.sbt.Sonatype.sonatypeCentralHost
 
-ThisBuild / organization := "com.velocidi"
+ThisBuild / organization := "com.kevel"
 
 ThisBuild / crossScalaVersions := Seq("2.12.20", "2.13.15")
 ThisBuild / scalaVersion       := "2.13.15"
@@ -85,7 +85,7 @@ lazy val docs = (project in file("apso-docs"))
     mdocOut := (ThisBuild / baseDirectory).value,
 
     mdocVariables := Map(
-      "VERSION" -> "0.18.8" // This version should be set to the currently released version.
+      "VERSION" -> "0.20.0" // This version should be set to the currently released version.
     ),
 
     publish / skip := true
@@ -161,6 +161,8 @@ lazy val commonSettings = Seq(
   )
   // format: on
 )
+
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 
 releaseCrossBuild    := true
 releaseTagComment    := s"Release ${(ThisBuild / version).value}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.velocidi/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.velocidi/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/workflows/CI/badge.svg?branch=master)](https://github.com/adzerk/apso/actions?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.12)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
@@ -11,7 +11,7 @@ Apso's latest release is built against Scala 2.12 and Scala 2.13.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso" % "@VERSION@"
 ```
 
 The project is divided in modules, you can instead install only a specific module.
@@ -19,7 +19,7 @@ The project is divided in modules, you can instead install only a specific modul
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-testkit" % "@VERSION@" % "test"
+libraryDependencies += "com.kevel" %% "apso-testkit" % "@VERSION@" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.
@@ -69,7 +69,7 @@ Please take into account that the library is still in an experimental stage and 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-core" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-core" % "@VERSION@"
 ```
 
 ### Config
@@ -268,7 +268,7 @@ The same features are provided for Pekko under the `pekko-http` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-akka-http" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-akka-http" % "@VERSION@"
 ```
 
 ### ClientIPDirectives
@@ -290,7 +290,7 @@ Apso provides a group of classes to ease the interaction with the Amazon Web Ser
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-aws" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-aws" % "@VERSION@"
 ```
 
 ### ConfigCredentialsProvider
@@ -337,7 +337,7 @@ The `apso-caching` module provides provides utilities for caching.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-caching" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-caching" % "@VERSION@"
 ```
 
 Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Guava` or `Caffeine` as underlying cache implementations.
@@ -381,7 +381,7 @@ y
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-collections" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-collections" % "@VERSION@"
 ```
 
 ### Trie
@@ -472,7 +472,7 @@ creation of the underlying Cyphers.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-encryption" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-encryption" % "@VERSION@"
 ```
 
 The following shows the creation of `Encryptor` and `Decryptor` objects,
@@ -498,7 +498,7 @@ decryptor.get.decryptToString(encryptor.get.encryptToSafeString(secretData).get)
 Apso provides utilities for various hashing functions. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-hashing" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-hashing" % "@VERSION@"
 ```
 
 ```scala mdoc:reset
@@ -516,7 +516,7 @@ Apso provides methods to deal with IO-related features in the `io` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-io" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-io" % "@VERSION@"
 ```
 
 ### FileDescriptor
@@ -559,7 +559,7 @@ ResourceUtil.getResourceAsString("reference.conf")
 Apso includes a bunch of utilities to work with JSON serialization and deserialization, specifically with the [circe](https://circe.github.io/circe/) library. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-circe" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-circe" % "@VERSION@"
 ```
 
 ### ExtraJsonProtocol
@@ -628,7 +628,7 @@ The `profiling` module of apso provides utilities to help with profiling the run
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-profiling" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-profiling" % "@VERSION@"
 ```
 
 ### CpuSampler
@@ -646,7 +646,7 @@ The `apso-time` module provides utilities to work with `DateTime` and `LocalDate
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.velocidi" %% "apso-time" % "@VERSION@"
+libraryDependencies += "com.kevel" %% "apso-time" % "@VERSION@"
 ```
 
 See the following sample usages:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.19.8-SNAPSHOT"
+ThisBuild / version := "0.20.0-SNAPSHOT"


### PR DESCRIPTION
Updates the publishing namespace from `com.velocidi` to `com.kevel`. I'm not sure if I'm going to need to override the `sonatypeRepository` (I needed to do it in a migrated namespace), but I'll check that out during the release.

### Does this change relate to existing issues or pull requests?

Follow-up to #745.

### Does this change require an update to the documentation?

Yes. The documentation was updated accordingly.

### How has this been tested?

I'm going to test out the publishing process once this gets merged.