### PR TITLE
Add a `uri` method to `FileDescriptor`

### DIFF
--- a/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.io
 
 import java.io.InputStream
+import java.net.URI
 
 import scala.io.Source
 
@@ -14,6 +15,13 @@ trait FileDescriptor {
     *   the unique identifier of this file in its location.
     */
   def path: String
+
+  /** Returns a Uniform Resource Identifier (URI) that references this file's location.
+    *
+    * @return
+    *   the URI that references this file's location.
+    */
+  def uri: URI
 
   /** The name of the file associated with the file descriptor.
     * @return

--- a/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
+++ b/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.io
 
 import java.io.{FileInputStream, FileWriter, InputStream}
+import java.net.URI
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 
 import scala.io.Source
@@ -20,6 +21,9 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   }
 
   lazy val path: String = file.getAbsolutePath
+
+  def uri: URI =
+    new URI(s"file://$path")
 
   lazy val name: String = file.getName
 
@@ -208,7 +212,8 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
     */
   def readString: String = Source.fromFile(file, "UTF-8").mkString
 
-  override def toString: String = s"file://$path"
+  override def toString: String =
+    uri.toString
 
   override def equals(other: Any): Boolean = other match {
     case that: LocalFileDescriptor => path == that.path

--- a/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
+++ b/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.io
 
 import java.io.InputStream
+import java.net.URI
 
 import scala.collection.concurrent.TrieMap
 
@@ -28,6 +29,9 @@ case class S3FileDescriptor(
 
   protected def duplicate(elements: List[String]) =
     this.copy(elements = elements)
+
+  def uri: URI =
+    new URI(s"s3://$path")
 
   def size = summary match {
     case Some(info) => info.getSize
@@ -134,7 +138,8 @@ case class S3FileDescriptor(
     result
   }
 
-  override def toString: String = s"s3://$path"
+  override def toString: String =
+    uri.toString
 }
 
 object S3FileDescriptor {

--- a/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
+++ b/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.io
 
 import java.io.{FileDescriptor => _, _}
+import java.net.URI
 import java.util.concurrent.{ConcurrentHashMap, TimeoutException}
 
 import scala.concurrent.duration._
@@ -99,6 +100,10 @@ case class SftpFileDescriptor(
       _fileAttributes = Some(sftp(_.stat(path)))
       withFileAttributes(f)
   }
+
+  def uri: URI =
+    if (port != 22) new URI(s"sftp://$username@$host:$port$path")
+    else new URI(s"sftp://$username@$host$path")
 
   def size = withFileAttributes(_.getSize)
 
@@ -200,8 +205,7 @@ case class SftpFileDescriptor(
   }
 
   override def toString: String =
-    if (port != 22) s"sftp://$username@$host:$port$path"
-    else s"sftp://$username@$host$path"
+    uri.toString
 
   override def equals(other: Any): Boolean = other match {
     case that: SftpFileDescriptor =>

--- a/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.io
 
 import java.io.{File, InputStream}
+import java.net.URI
 import java.nio.file.Files
 import java.util.UUID
 
@@ -21,6 +22,13 @@ class LocalFileDescriptorSpec extends Specification {
       val file = new File("/tmp/one/two/three")
       val fd = LocalFileDescriptor("/tmp/one/two/three")
       file.getAbsolutePath == fd.path
+    }
+
+    "have a correct URI that exposes the full path" in {
+      val file = new File("/tmp/one/two/three")
+      val fd = LocalFileDescriptor("/tmp/one/two/three")
+      fd.uri ==== new URI("file:///tmp/one/two/three")
+      file.toURI() ==== fd.uri
     }
 
     "retrieve the size of a file" in {

--- a/io/src/test/scala/com/kevel/apso/io/S3FileDescriptorSpec.scala
+++ b/io/src/test/scala/com/kevel/apso/io/S3FileDescriptorSpec.scala
@@ -1,0 +1,14 @@
+package com.kevel.apso.io
+
+import java.net.URI
+
+import org.specs2.mutable.Specification
+
+class S3FileDescriptorSpec extends Specification {
+  "A S3FileDescriptor" should {
+    "have a correct URI that exposes the full path" in {
+      val file = S3FileDescriptor("bucket/key")
+      file.uri ==== new URI("s3://bucket/key")
+    }
+  }
+}

--- a/io/src/test/scala/com/kevel/apso/io/SftpFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/kevel/apso/io/SftpFileDescriptorSpec.scala
@@ -1,0 +1,19 @@
+package com.kevel.apso.io
+
+import java.net.URI
+
+import org.specs2.mutable.Specification
+
+import com.kevel.apso.io.config.Credentials
+
+class SftpFileDescriptorSpec extends Specification {
+  "A SftpFileDescriptor" should {
+    "have a correct URI that exposes the full path" in {
+      val file = SftpFileDescriptor(
+        "localhost/tmp/file",
+        Credentials.Sftp(default = Some(Credentials.Sftp.Entry.Basic(username = "user123", password = "pass456")))
+      )
+      file.uri ==== new URI("sftp://user123@localhost/tmp/file")
+    }
+  }
+}


### PR DESCRIPTION
Enables the `FileDescriptor` interface with a `uri` method that returns a `java.net.URI` with a reference to the file's location.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

New unit tests were added for the change.