### PR TITLE
Make fromFullPaths tail recursive

### DIFF
--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -1,5 +1,6 @@
 package com.kevel.apso.circe
 
+import scala.annotation.tailrec
 import scala.util.Try
 
 import io.circe._
@@ -110,10 +111,13 @@ object Implicits {
     *   the sequence of dot-separated (or other separator) paths
     * @param separatorRegex
     *   regex to use to separate fields
+    * @param acc
+    *   accumulator for the resulting Json object
     * @return
     *   the resulting Json object
     */
-  def fromFullPaths(paths: Seq[(String, Json)], separatorRegex: String = "\\."): Json = {
+  @tailrec
+  def fromFullPaths(paths: Seq[(String, Json)], separatorRegex: String = "\\.", acc: Json = Json.obj()): Json = {
     def createJson(keys: Seq[String], value: Json): Json = {
       keys match {
         case Nil    => value
@@ -122,9 +126,10 @@ object Implicits {
     }
 
     paths match {
-      case Nil => Json.obj()
+      case Nil => acc
       case (path, value) :: rem =>
-        createJson(path.split(separatorRegex).toList, value).deepMerge(fromFullPaths(rem, separatorRegex))
+        val newAcc = acc.deepMerge(createJson(path.split(separatorRegex).toList, value))
+        fromFullPaths(rem, separatorRegex, newAcc)
     }
   }
 

--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -111,13 +111,10 @@ object Implicits {
     *   the sequence of dot-separated (or other separator) paths
     * @param separatorRegex
     *   regex to use to separate fields
-    * @param acc
-    *   accumulator for the resulting Json object
     * @return
     *   the resulting Json object
     */
-  @tailrec
-  def fromFullPaths(paths: Seq[(String, Json)], separatorRegex: String = "\\.", acc: Json = Json.obj()): Json = {
+  def fromFullPaths(paths: Seq[(String, Json)], separatorRegex: String = "\\."): Json = {
     def createJson(keys: Seq[String], value: Json): Json = {
       keys match {
         case Nil    => value
@@ -125,12 +122,17 @@ object Implicits {
       }
     }
 
-    paths match {
-      case Nil => acc
-      case (path, value) :: rem =>
-        val newAcc = acc.deepMerge(createJson(path.split(separatorRegex).toList, value))
-        fromFullPaths(rem, separatorRegex, newAcc)
+    @tailrec
+    def fromFullPathsRec(paths: Seq[(String, Json)], acc: Json): Json = {
+      paths match {
+        case Nil => acc
+        case (path, value) :: rem =>
+          val newAcc = acc.deepMerge(createJson(path.split(separatorRegex).toList, value))
+          fromFullPathsRec(rem, newAcc)
+      }
     }
+
+    fromFullPathsRec(paths, Json.obj())
   }
 
   final implicit class ApsoJsonEncoder[A](val encoder: Encoder[A]) extends AnyVal {

--- a/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
+++ b/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
@@ -33,8 +33,11 @@ class ImplicitsSpec extends Specification {
       }
 
       "giving precedence to the last path value if duplicate paths exist" in {
-        val res = fromFullPaths(List("a" -> 1.asJson, "a" -> 2.asJson, "a" -> 3.asJson))
-        res mustEqual json"""{"a": 3}"""
+        val json1 = fromFullPaths(List("a" -> 1.asJson, "a" -> 2.asJson, "a" -> 3.asJson))
+        json1 mustEqual json"""{"a": 3}"""
+
+        val json2 = fromFullPaths(List("a.b.c" -> 1.asJson, "a.b" -> 2.asJson, "a" -> 3.asJson))
+        json2 mustEqual json"""{"a": 3}"""
       }
     }
 

--- a/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
+++ b/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
@@ -31,6 +31,11 @@ class ImplicitsSpec extends Specification {
         val paths = (1 to 10000).map(i => (s"a.v$i", i.asJson)).toList
         fromFullPaths(paths, ".") must not(throwAn[StackOverflowError])
       }
+
+      "giving precedence to the last path value if duplicate paths exist" in {
+        val res = fromFullPaths(List("a" -> 1.asJson, "a" -> 2.asJson, "a" -> 3.asJson))
+        res mustEqual json"""{"a": 3}"""
+      }
     }
 
     "provide a method to get the key set of a JSON Object" in {

--- a/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
+++ b/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
@@ -26,6 +26,11 @@ class ImplicitsSpec extends Specification {
 
         res mustEqual expectedJson
       }
+
+      "not throw a StackOverflowError for large lists of paths" in {
+        val paths = (1 to 10000).map(i => (s"a.v$i", i.asJson)).toList
+        fromFullPaths(paths, ".") must not(throwAn[StackOverflowError])
+      }
     }
 
     "provide a method to get the key set of a JSON Object" in {


### PR DESCRIPTION
This proposes making `fromFullPaths` tail recursive to avoid `StackOverflow` exceptions if the size of the `paths` parameter is too long.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

Existing and new unit tests.
