### PR TITLE
Install sbt in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: sbt
 
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Update dependencies
         if: steps.setup-java.outputs.cache-hit == 'false'
         run: sbt +update


### PR DESCRIPTION
sbt is no longer available in the most recent Ubuntu runners (see https://github.com/actions/setup-java/issues/712#issuecomment-2557396980). This starts intalling sbt explicitly. 

Failures running the actions can be seen [in this run](https://github.com/adzerk/apso/actions/runs/12580694755) (which I triggered manually just to exhibit the issue).

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

Failures of runs without this change can be seen [here](https://github.com/adzerk/apso/actions/runs/12580694755). Hopefully the runs in this PR will be OK.