### PR TITLE
Update SCM connection string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val commonSettings = Seq(
   scmInfo := Some(
     ScmInfo(
       url("https://github.com/adzerk/apso"),
-      "scm:git@github.com:adzerk/apso.git"
+      "scm:git:ssh://git@github.com/adzerk/apso.git"
     )
   )
   // format: on


### PR DESCRIPTION
Updates the SCM connection string to a format known to be valid.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

N/A