### PR TITLE
Start cross-compiling apso-io to Scala 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso" % "0.21.0"
 ```
 
-The project is divided in modules, you can instead install only a specific module. Some modules are already available for Scala 3. Currently, only apso-elasticsearch and apso-io are not available for Scala 3.
+The project is divided in modules, you can instead install only a specific module. Some modules are already available for Scala 3. Currently, only apso-elasticsearch is not available for Scala 3.
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 

--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val hashing = module(project, "hashing")
 lazy val io = module(project, "io")
   .dependsOn(aws, testkit % Test)
   .settings(
-    crossScalaVersions := List(Versions.Scala212, Versions.Scala213),
+    crossScalaVersions := List(Versions.Scala212, Versions.Scala213, Versions.Scala3),
     libraryDependencies ++= Seq(
       AwsJavaSdkCore,
       AwsJavaSdkS3,
@@ -149,7 +149,10 @@ lazy val io = module(project, "io")
       BouncyCastleProvider,
       ScalaCollectionCompat,
       ScalaLogging,
-      ScalaPool,
+      // FIXME: scala-pool is not avaiable for Scala 3, but we can use the Scala 2.13 version. This is currently only
+      //        being used to manage pools of SFTP clients for the same connection details. We should eventually
+      //        consider an alternative implementation.
+      ScalaPool.cross(CrossVersion.for3Use2_13),
       SshJ,
       TypesafeConfig,
       Specs2Core % Test

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso" % "@VERSION@"
 ```
 
-The project is divided in modules, you can instead install only a specific module. Some modules are already available for Scala 3. Currently, only apso-elasticsearch and apso-io are not available for Scala 3.
+The project is divided in modules, you can instead install only a specific module. Some modules are already available for Scala 3. Currently, only apso-elasticsearch is not available for Scala 3.
 
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 

--- a/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
+++ b/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
@@ -250,7 +250,7 @@ class LocalFileDescriptorSpec extends Specification {
 
       fd.listAllFilesWithPrefix("aaa/ggg").toList must haveSize(3)
       fd.listAllFilesWithPrefix("").toList must haveSize(8)
-      dir3.listAllFilesWithPrefix("") must beEmpty
+      dir3.listAllFilesWithPrefix("").toList must beEmpty
     }
 
     "know whether the FD points to a directory" in {


### PR DESCRIPTION
This enables cross-compiling apso-io to Scala 3. [scala-pool](https://github.com/andresilva/scala-pool) is not available for Scala 3, but we can use the Scala 2.13 version.

### Does this change relate to existing issues or pull requests?

This depends on #807.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I made sure we continue to be able to build the project successfully.