### PR TITLE
Remove Guava option from apso-caching

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,8 +5,7 @@ dependencyOverrides = [
 
 updates {
   ignore = [
-    { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine" }, # This needs scalacache-caffeine to update as well
-    { groupId = "com.google.guava", artifactId = "guava" } # This needs scalacache-guava to update as well
+    { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine" } # This needs scalacache-caffeine to update as well
   ]
 
   pin = [

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "0.21.0"
 ```
 
-Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Guava` or `Caffeine` as underlying cache implementations.
+Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Caffeine` as the underlying cache implementation.
 
 These utilities are provided as `cached()` and `cachedF()` extension methods over all `FunctionN[]` types:
 
@@ -390,7 +390,7 @@ val y = new AtomicInteger(0)
 val cachedFutFn = ((i: Int) => Future {
   val value = y.getAndAdd(i)
   value
-}).cachedF(config.Cache.Guava(Some(2), None))
+}).cachedF(config.Cache.Caffeine(Some(2), None))
 // cachedFutFn: MemoizeFn1[Future, Int, Int] = <function1>
 
 Await.result(cachedFutFn(3), Duration.Inf)

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "0.21.0"
 ```
 
-Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Caffeine` as the underlying cache implementation.
+Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using `Caffeine` as the underlying cache implementation.
 
 These utilities are provided as `cached()` and `cachedF()` extension methods over all `FunctionN[]` types:
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,6 @@ lazy val caching = module(project, "caching")
       "com.github.ben-manes.caffeine" % "caffeine"            % "2.7.0",    // This wasn't updated due to incompatibility with scalacache-caffeine
       "com.github.cb372"             %% "scalacache-caffeine" % "0.28.0",
       "com.github.cb372"             %% "scalacache-core"     % "0.28.0",
-      "com.github.cb372"             %% "scalacache-guava"    % "0.28.0",
-      "com.google.guava"              % "guava"               % "28.0-jre", // This wasn't updated due to incompatibility with scalacache-guava
       ConcurrentLinkedHashMapLru,
       ScalaCollectionCompat,
       Specs2Core                      % Test

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val caching = module(project, "caching")
   .enablePlugins(BoilerplatePlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.github.ben-manes.caffeine" % "caffeine"            % "2.7.0",    // This wasn't updated due to incompatibility with scalacache-caffeine
+      "com.github.ben-manes.caffeine" % "caffeine"            % "2.7.0", // This wasn't updated due to incompatibility with scalacache-caffeine
       "com.github.cb372"             %% "scalacache-caffeine" % "0.28.0",
       "com.github.cb372"             %% "scalacache-core"     % "0.28.0",
       ConcurrentLinkedHashMapLru,

--- a/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
+++ b/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
@@ -41,7 +41,7 @@ override def apply([#i0: I0#]) = memoizeF(cacheConf.ttl)(fn([#i0#]))
   * Provides methods to cache/memoize a given function using ScalaCache.
   *
   * The provided `function` param is memoized using ScalaCache and the client can provide a `config.Cache` object
-  * to configure the underlying cache engine, such as type (caffeine, guava), size and time-to-live.
+  * to configure the underlying cache engine, such as type (caffeine), size and time-to-live.
   *
   * Each method returns a `MemoizeFn*` object, according to the number of arguments of the input function, which
   * provides a corresponding `apply()` method. This method signature follows the signature of the provided function,

--- a/caching/src/main/scala/com/kevel/apso/caching/config/Cache.scala
+++ b/caching/src/main/scala/com/kevel/apso/caching/config/Cache.scala
@@ -25,21 +25,4 @@ object Cache {
       )
     }
   }
-
-  case class Guava(size: Option[Long], ttl: Option[FiniteDuration]) extends Cache {
-    def implementation[V]: scalacache.Cache[V] = {
-      import com.google.common.cache.CacheBuilder
-      import scalacache._
-      import scalacache.guava._
-
-      val builder = CacheBuilder.newBuilder()
-
-      GuavaCache(
-        size
-          .map(builder.maximumSize)
-          .getOrElse(builder)
-          .build[String, Entry[V]]
-      )
-    }
-  }
 }

--- a/caching/src/test/boilerplate/com/kevel/apso/caching/BaseMemoizeFnSpec.scala.template
+++ b/caching/src/test/boilerplate/com/kevel/apso/caching/BaseMemoizeFnSpec.scala.template
@@ -9,13 +9,6 @@ import scala.util.Random
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.mutable.Specification
 
-class MemoizeFnWithGuavaSpec(implicit ee: ExecutionEnv) extends BaseMemoizeFnSpec()(ee) {
-  def newConf(size: Option[Long] = None, ttl: Option[FiniteDuration] = None) = {
-    config.Cache.Guava(size, ttl)
-  }
-  lazy val underlyingCacheName = "Guava"
-}
-
 class MemoizeFnWithCaffeineSpec(implicit ee: ExecutionEnv) extends BaseMemoizeFnSpec()(ee) {
   def newConf(size: Option[Long] = None, ttl: Option[FiniteDuration] = None) = {
     config.Cache.Caffeine(size, ttl)

--- a/docs/README.md
+++ b/docs/README.md
@@ -338,7 +338,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "@VERSION@"
 ```
 
-Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Caffeine` as the underlying cache implementation.
+Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using `Caffeine` as the underlying cache implementation.
 
 These utilities are provided as `cached()` and `cachedF()` extension methods over all `FunctionN[]` types:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -338,7 +338,7 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "@VERSION@"
 ```
 
-Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Guava` or `Caffeine` as underlying cache implementations.
+Apso provides utilities to simplify the caching of method calls, with [ScalaCache](https://cb372.github.io/scalacache/) and using either `Caffeine` as the underlying cache implementation.
 
 These utilities are provided as `cached()` and `cachedF()` extension methods over all `FunctionN[]` types:
 
@@ -367,7 +367,7 @@ val y = new AtomicInteger(0)
 val cachedFutFn = ((i: Int) => Future {
   val value = y.getAndAdd(i)
   value
-}).cachedF(config.Cache.Guava(Some(2), None))
+}).cachedF(config.Cache.Caffeine(Some(2), None))
 
 Await.result(cachedFutFn(3), Duration.Inf)
 Await.result(cachedFutFn(3), Duration.Inf)


### PR DESCRIPTION
The Guava implementation has been removed from ScalaCache in https://github.com/cb372/scalacache/pull/362. This follows along and removes it from apso-caching.

### Does this change relate to existing issues or pull requests?

This depends on #803.

### Does this change require an update to the documentation?

Yes. The documentation was updated accordingly.

### How has this been tested?

I made sure we continue to be able to build the project successfully.