### PR TITLE
Drop support for Scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,6 @@ jobs:
     name: Scala ${{ matrix.scala }} (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        scala: ['2.12', '2.13']
-        java: ['11', '17', '21']
-        include:
-          - scala: '2.12'
-            scala-version: 2.12.20
-          - scala: '2.13'
-            scala-version: 2.13.16
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -42,11 +31,11 @@ jobs:
 
       - name: Compile and check format
         run: >-
-          sbt ++${{ matrix.scala-version }} scalafmtSbt Test/compile &&
+          sbt Test/compile &&
           git diff --exit-code
 
       - name: Run tests
-        run: sbt -Dsbt.color=always ++${{ matrix.scala-version }} test
+        run: sbt -Dsbt.color=always test
 
       - name: Check mdoc for uncommitted changes
         run: sbt -Dsbt.color=always "docs/mdoc --check"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ jobs:
     name: CI (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['11', '17', '21']
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: Scala ${{ matrix.scala }} (Java ${{ matrix.java }})
+    name: CI (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/adzerk/apso/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/adzerk/apso/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.13.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.13)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
 ## Installation
 
-Apso's latest release is built against Scala 2.12 and Scala 2.13.
+Apso's latest release is built against Scala 2.13.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / organization := "com.kevel"
 
-ThisBuild / crossScalaVersions := Seq("2.12.20", "2.13.16")
 ThisBuild / scalaVersion       := "2.13.16"
 
 val javaVersion = "11"
@@ -26,7 +25,6 @@ lazy val aws = module(project, "aws")
       ScalaLogging,
       AwsJavaSdkS3,
       AwsJavaSdkCore,
-      ScalaCollectionCompat,
       ScalaLogging,
       TypesafeConfig,
       Specs2Core % Test
@@ -43,7 +41,6 @@ lazy val caching = module(project, "caching")
       "com.github.cb372"             %% "scalacache-guava"    % "0.28.0",
       "com.google.guava"              % "guava"               % "28.0-jre", // This wasn't updated due to incompatibility with scalacache-guava
       ConcurrentLinkedHashMapLru,
-      ScalaCollectionCompat,
       Specs2Core                      % Test
     )
   )
@@ -55,7 +52,6 @@ lazy val circe = module(project, "circe").settings(
     CirceGeneric,
     CirceParser,
     JodaTime       % Provided,
-    ScalaCollectionCompat,
     Squants        % Provided,
     TypesafeConfig % Provided,
     CirceLiteral   % Test,
@@ -67,7 +63,6 @@ lazy val circe = module(project, "circe").settings(
 lazy val collections = module(project, "collections").settings(
   libraryDependencies ++= Seq(
     ScalaCheck            % Test,
-    ScalaCollectionCompat % Test,
     Specs2Core            % Test,
     Specs2ScalaCheck      % Test
   )
@@ -78,7 +73,6 @@ lazy val core = module(project, "core")
   .settings(
     libraryDependencies ++= Seq(
       CirceCore,
-      ScalaCollectionCompat,
       ScalaLogging,
       TypesafeConfig   % Provided,
       UnirestJava,
@@ -131,7 +125,6 @@ lazy val io = module(project, "io")
       // Remove once com.hierynomus:sshj releases a version with https://github.com/hierynomus/sshj/pull/938
       BouncyCastlePkix,
       BouncyCastleProvider,
-      ScalaCollectionCompat,
       ScalaLogging,
       ScalaPool,
       SshJ,
@@ -244,31 +237,18 @@ lazy val commonSettings = Seq(
   semanticdbVersion := scalafixSemanticdb.revision,
   scalafixOnCompile := true,
 
-  scalacOptions ++= {
-    lazy val commonFlags = Seq(
-      "-encoding", "UTF-8",
-      "-language:higherKinds",
-      "-language:implicitConversions",
-      "-feature",
-      "-unchecked",
-      "-deprecation",
-      "-release", javaVersion,
-      "-Xfatal-warnings",
-      "-Ywarn-dead-code")
-
-    def withCommon(flags: String*) =
-      commonFlags ++ flags
-
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 12)) =>
-        withCommon(
-          "-Ywarn-unused-import")
-
-      case _ =>
-        withCommon(
-          "-Ywarn-unused:imports")
-    }
-  },
+  scalacOptions ++= Seq(
+    "-encoding", "UTF-8",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-feature",
+    "-unchecked",
+    "-deprecation",
+    "-release", javaVersion,
+    "-Xfatal-warnings",
+    "-Ywarn-dead-code",
+    "-Ywarn-unused:imports"
+  ),
 
   javacOptions ++= List(
     "--release", javaVersion

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 
 ThisBuild / organization := "com.kevel"
 
-ThisBuild / scalaVersion       := "2.13.16"
+ThisBuild / scalaVersion := "2.13.16"
 
 val javaVersion = "11"
 
@@ -62,9 +62,9 @@ lazy val circe = module(project, "circe").settings(
 
 lazy val collections = module(project, "collections").settings(
   libraryDependencies ++= Seq(
-    ScalaCheck            % Test,
-    Specs2Core            % Test,
-    Specs2ScalaCheck      % Test
+    ScalaCheck       % Test,
+    Specs2Core       % Test,
+    Specs2ScalaCheck % Test
   )
 )
 

--- a/circe/src/main/scala/com/kevel/apso/circe/JsonConvert.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/JsonConvert.scala
@@ -1,6 +1,5 @@
 package com.kevel.apso.circe
 
-import scala.collection.compat._
 import scala.jdk.CollectionConverters._
 
 import io.circe.syntax._

--- a/collections/src/test/scala/com/kevel/apso/iterator/ImplicitsSpec.scala
+++ b/collections/src/test/scala/com/kevel/apso/iterator/ImplicitsSpec.scala
@@ -1,7 +1,5 @@
 package com.kevel.apso.iterator
 
-import scala.collection.compat.immutable.LazyList
-
 import org.specs2.mutable._
 
 import com.kevel.apso.iterator.Implicits._

--- a/core/src/main/scala/com/kevel/apso/Implicits.scala
+++ b/core/src/main/scala/com/kevel/apso/Implicits.scala
@@ -1,7 +1,7 @@
 package com.kevel.apso
 
 import scala.annotation.tailrec
-import scala.collection.compat._
+import scala.collection.Factory
 import scala.util.{Random, Try, Using}
 
 /** Object containing implicit classes and methods of general purpose.
@@ -289,8 +289,8 @@ object Implicits {
       * @return
       *   ordered stream of doubles
       */
-    def decreasingUniformStream(n: Int): immutable.LazyList[Double] =
-      immutable.LazyList
+    def decreasingUniformStream(n: Int): LazyList[Double] =
+      LazyList
         .iterate((n + 1, 1.0), n + 1) { case (i, currMax) => (i - 1, currMax * math.pow(rand.nextDouble(), 1.0 / i)) }
         .tail
         .map(_._2)
@@ -303,7 +303,7 @@ object Implicits {
       * @return
       *   ordered stream of doubles
       */
-    def increasingUniformStream(n: Int): immutable.LazyList[Double] =
+    def increasingUniformStream(n: Int): LazyList[Double] =
       decreasingUniformStream(n).map(1 - _)
   }
 

--- a/core/src/test/scala/com/kevel/apso/ImplicitsSpec.scala
+++ b/core/src/test/scala/com/kevel/apso/ImplicitsSpec.scala
@@ -1,6 +1,5 @@
 package com.kevel.apso
 
-import scala.collection.compat._
 import scala.util.Random
 
 import org.specs2.ScalaCheck
@@ -40,7 +39,7 @@ class ImplicitsSpec extends Specification with ScalaCheck with FutureExtraMatche
       rand.setSeed(0)
       val runs = 10000
       val n = 5
-      val elems = immutable.LazyList.iterate(0, 50) { _ + 1 }
+      val elems = LazyList.iterate(0, 50) { _ + 1 }
 
       val tests = (1 to runs).map { _ => rand.chooseN(elems, n) }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 <p align="center"><img src="https://raw.githubusercontent.com/adzerk/apso/master/apso.png"/></p>
 
-# Apso [![Build Status](https://github.com/adzerk/apso/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/adzerk/apso/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.12)
+# Apso [![Build Status](https://github.com/adzerk/apso/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/adzerk/apso/actions/workflows/ci.yml?query=workflow%3ACI+branch%3Amaster) [![Maven Central](https://img.shields.io/maven-central/v/com.kevel/apso_2.13.svg)](https://maven-badges.herokuapp.com/maven-central/com.kevel/apso_2.13)
 
 Apso is Kevel's collection of Scala utility libraries. It provides a series of useful methods.
 
 ## Installation
 
-Apso's latest release is built against Scala 2.12 and Scala 2.13.
+Apso's latest release is built against Scala 2.13.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,6 @@ object Dependencies {
   val PekkoStreamTestkit         = "org.apache.pekko"                      %% "pekko-stream-testkit"         % Versions.Pekko
   val PekkoTestkit               = "org.apache.pekko"                      %% "pekko-testkit"                % Versions.Pekko
   val ScalaCheck                 = "org.scalacheck"                        %% "scalacheck"                   % Versions.ScalaCheck
-  val ScalaCollectionCompat      = "org.scala-lang.modules"                %% "scala-collection-compat"      % "2.13.0"
   val ScalaLogging               = "com.typesafe.scala-logging"            %% "scala-logging"                % Versions.ScalaLogging
   val ScalaPool                  = "io.github.andrebeat"                   %% "scala-pool"                   % Versions.ScalaPool
   val ScalaTestCore              = "org.scalatest"                         %% "scalatest-core"               % Versions.ScalaTest


### PR DESCRIPTION
Recent Scala versions have been deprecating some Scala 2 syntax, and there doesn't seem to be a high demand for a Scala 2.12 version of Apso downstream. As such, this PR proposes removing support for Scala 2.12 altogether.

### Does this change relate to existing issues or pull requests?

Resolves #812.

### Does this change require an update to the documentation?

Yes. The README was updated accordingly.

### How has this been tested?

I made sure we continue to be able to build the project successfully.