### PR TITLE
Remove Scala Steward pins related to Elasticsearch dependencies

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,14 +7,4 @@ updates {
   ignore = [
     { groupId = "com.github.ben-manes.caffeine", artifactId = "caffeine" } # This needs scalacache-caffeine to update as well
   ]
-
-  pin = [
-    # We want to have jackson-databind at a version that is binary compatible with the one elastic4s uses but that
-    # doesn't expose known vulnerabilities.
-    { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.13.5" },
-    { groupId = "com.sksamuel.elastic4s", version = "7.16." },
-    { groupId = "org.codelibs", artifactId = "elasticsearch-cluster-runner", version = "7.16." },
-    { groupId = "org.elasticsearch", artifactId = "elasticsearch", version = "7.16." },
-    { groupId = "org.elasticsearch.client", artifactId = "elasticsearch-rest-client", version = "7.16." }
-  ]
 }


### PR DESCRIPTION
As a follow-up to the removal of apso-elasticsearch, we no longer need to pin these updates.

### Does this change relate to existing issues or pull requests?

This is a follow-up to #811.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I made sure we weren't depending on any artifact mentioned in the removed list.