### PR TITLE
Use builders and avoid Sets in flattenedKeyValueSet

### DIFF
--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -19,9 +19,9 @@ object Implicits {
       separator: String,
       ignoreNull: Boolean,
       onLeaf: (String, Json) => V
-  ): Vector[V] = {
+  ): Set[V] = {
     val prefixesAndJsons = mutable.Queue.empty[(String, Json)]
-    val builder = Vector.newBuilder[V]
+    val builder = Set.newBuilder[V]
 
     prefixesAndJsons.enqueue(("", json))
 
@@ -56,7 +56,7 @@ object Implicits {
       *   flattened key set
       */
     def flattenedKeyValueSet(separator: String = "."): Set[(String, Json)] = {
-      flattenJson(json, separator, ignoreNull = false, onLeaf = (k, v) => (k, v)).toSet
+      flattenJson(json, separator, ignoreNull = false, onLeaf = (k, v) => (k, v))
     }
 
     /** Returns a set of keys of this object where nested keys are separated by a separator character.
@@ -71,7 +71,7 @@ object Implicits {
       *   flattened key set
       */
     def flattenedKeySet(separator: String = ".", ignoreNull: Boolean = true): Set[String] =
-      flattenJson(json, separator, ignoreNull, onLeaf = (k, _) => k).toSet
+      flattenJson(json, separator, ignoreNull, onLeaf = (k, _) => k)
 
     /** Returns the value of the field on the end of the tree, separated by the separator character.
       *

--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -18,7 +18,7 @@ object Implicits {
       case None => Vector.empty
       case Some(jo) =>
         val builder = Vector.newBuilder[(String, Json)]
-        jo.toMap.foreach {
+        jo.toIterable.foreach {
           case (k, v) if v.isObject =>
             flattenedKeyValueSetAux(v, separator).foreach { case (kk, vv) =>
               val path = new StringBuilder(k.length + separator.length + kk.length)

--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -15,20 +15,20 @@ object Implicits {
   }
 
   private def flattenedKeySetAux(json: Json, separator: String, ignoreNull: Boolean): Vector[String] = {
-    val jsonsAndPrefixes = mutable.Queue.empty[(String, Json)]
+    val prefixesAndJsons = mutable.Queue.empty[(String, Json)]
     val builder = Vector.newBuilder[String]
 
-    jsonsAndPrefixes.enqueue(("", json))
+    prefixesAndJsons.enqueue(("", json))
 
-    while (jsonsAndPrefixes.nonEmpty) {
-      val (prefix, nextJson) = jsonsAndPrefixes.dequeue()
+    while (prefixesAndJsons.nonEmpty) {
+      val (prefix, nextJson) = prefixesAndJsons.dequeue()
 
       nextJson.asObject.foreach(jsonObject =>
         jsonObject.toIterable.foreach({ case (k, v) =>
           if (!(ignoreNull && v.isNull)) {
             val kk = if (prefix.nonEmpty) s"$prefix$separator$k" else k
             if (v.isObject) {
-              jsonsAndPrefixes.enqueue((kk, v))
+              prefixesAndJsons.enqueue((kk, v))
             } else {
               builder += kk
             }
@@ -41,20 +41,20 @@ object Implicits {
   }
 
   private def flattenedKeyValueSetAux(json: Json, separator: String, ignoreNull: Boolean): Vector[(String, Json)] = {
-    val jsonsAndPrefixes = mutable.Queue.empty[(String, Json)]
+    val prefixesAndJsons = mutable.Queue.empty[(String, Json)]
     val builder = Vector.newBuilder[(String, Json)]
 
-    jsonsAndPrefixes.enqueue(("", json))
+    prefixesAndJsons.enqueue(("", json))
 
-    while (jsonsAndPrefixes.nonEmpty) {
-      val (prefix, nextJson) = jsonsAndPrefixes.dequeue()
+    while (prefixesAndJsons.nonEmpty) {
+      val (prefix, nextJson) = prefixesAndJsons.dequeue()
 
       nextJson.asObject.foreach(jsonObject =>
         jsonObject.toIterable.foreach({ case (k, v) =>
           if (!(ignoreNull && v.isNull)) {
             val kk = if (prefix.nonEmpty) s"$prefix$separator$k" else k
             if (v.isObject) {
-              jsonsAndPrefixes.enqueue((kk, v))
+              prefixesAndJsons.enqueue((kk, v))
             } else {
               builder += ((kk, v))
             }

--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -15,24 +15,20 @@ object Implicits {
   }
 
   private def flattenedKeyValueSetAux(json: Json, separator: String, ignoreNull: Boolean): Vector[(String, Json)] = {
-    val jsons = mutable.Queue.empty[Json]
-    val prefixes = mutable.Queue.empty[String]
+    val jsonsAndPrefixes = mutable.Queue.empty[(String, Json)]
     val builder = Vector.newBuilder[(String, Json)]
 
-    jsons.enqueue(json)
-    prefixes.enqueue("")
+    jsonsAndPrefixes.enqueue(("", json))
 
-    while (jsons.nonEmpty) {
-      val j = jsons.dequeue()
-      val p = prefixes.dequeue()
+    while (jsonsAndPrefixes.nonEmpty) {
+      val (prefix, json) = jsonsAndPrefixes.dequeue()
 
-      j.asObject.foreach(jo =>
+      json.asObject.foreach(jo =>
         jo.toIterable.foreach({ case (k, v) =>
           if (!(ignoreNull && v.isNull)) {
-            val kk = if (p.nonEmpty) s"$p$separator$k" else k
+            val kk = if (prefix.nonEmpty) s"$prefix$separator$k" else k
             if (v.isObject) {
-              jsons.enqueue(v)
-              prefixes.enqueue(kk)
+              jsonsAndPrefixes.enqueue((kk, v))
             } else {
               builder += ((kk, v))
             }

--- a/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
+++ b/circe/src/main/scala/com/kevel/apso/circe/Implicits.scala
@@ -1,6 +1,7 @@
 package com.kevel.apso.circe
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.util.Try
 
 import io.circe._
@@ -13,26 +14,34 @@ object Implicits {
     def unapply(str: String) = Try(str.toInt).toOption
   }
 
-  private def flattenedKeyValueSetAux(json: Json, separator: String = "."): Vector[(String, Json)] = {
-    json.asObject match {
-      case None => Vector.empty
-      case Some(jo) =>
-        val builder = Vector.newBuilder[(String, Json)]
-        jo.toIterable.foreach {
-          case (k, v) if v.isObject =>
-            flattenedKeyValueSetAux(v, separator).foreach { case (kk, vv) =>
-              val path = new StringBuilder(k.length + separator.length + kk.length)
-                .append(k)
-                .append(separator)
-                .append(kk)
-                .toString
-              builder += ((path, vv))
+  private def flattenedKeyValueSetAux(json: Json, separator: String, ignoreNull: Boolean): Vector[(String, Json)] = {
+    val jsons = mutable.Queue.empty[Json]
+    val prefixes = mutable.Queue.empty[String]
+    val builder = Vector.newBuilder[(String, Json)]
+
+    jsons.enqueue(json)
+    prefixes.enqueue("")
+
+    while (jsons.nonEmpty) {
+      val j = jsons.dequeue()
+      val p = prefixes.dequeue()
+
+      j.asObject.foreach(jo =>
+        jo.toIterable.foreach({ case (k, v) =>
+          if (!(ignoreNull && v.isNull)) {
+            val kk = if (p.nonEmpty) s"$p$separator$k" else k
+            if (v.isObject) {
+              jsons.enqueue(v)
+              prefixes.enqueue(kk)
+            } else {
+              builder += ((kk, v))
             }
-          case (k, v) =>
-            builder += ((k, v))
-        }
-        builder.result()
+          }
+        })
+      )
     }
+
+    builder.result()
   }
 
   final implicit class ApsoJsonObject(val json: Json) extends AnyVal {
@@ -47,7 +56,7 @@ object Implicits {
       *   flattened key set
       */
     def flattenedKeyValueSet(separator: String = "."): Set[(String, Json)] = {
-      flattenedKeyValueSetAux(json, separator).toSet
+      flattenedKeyValueSetAux(json, separator, ignoreNull = false).toSet
     }
 
     /** Returns a set of keys of this object where nested keys are separated by a separator character.
@@ -62,12 +71,7 @@ object Implicits {
       *   flattened key set
       */
     def flattenedKeySet(separator: String = ".", ignoreNull: Boolean = true): Set[String] =
-      flattenedKeyValueSetAux(json, separator)
-        .filter { case (_, v) =>
-          !ignoreNull || !v.isNull
-        }
-        .map(_._1)
-        .toSet
+      flattenedKeyValueSetAux(json, separator, ignoreNull).map(_._1).toSet
 
     /** Returns the value of the field on the end of the tree, separated by the separator character.
       *

--- a/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
+++ b/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
@@ -1,5 +1,6 @@
 package com.kevel.apso.circe
 
+import io.circe.Json
 import io.circe.generic.semiauto._
 import io.circe.literal._
 import io.circe.syntax._
@@ -47,7 +48,17 @@ class ImplicitsSpec extends Specification {
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
+
       1.asJson.flattenedKeySet() === Set.empty
+    }
+
+    "provide a method to get the key-value set of a JSON Object" in {
+      val obj = json"""{"a":1,"b":{"c":2},"d":null}"""
+
+      obj.flattenedKeyValueSet(".") === Set(("a", Json.fromInt(1)), ("b.c", Json.fromInt(2)), ("d", Json.Null))
+      obj.flattenedKeyValueSet("/") === Set(("a", Json.fromInt(1)), ("b/c", Json.fromInt(2)), ("d", Json.Null))
+
+      1.asJson.flattenedKeyValueSet() === Set.empty
     }
 
     "provide a method to get a field from a JSON object" in {

--- a/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
+++ b/circe/src/test/scala/com/kevel/apso/circe/ImplicitsSpec.scala
@@ -44,21 +44,23 @@ class ImplicitsSpec extends Specification {
 
     "provide a method to get the key set of a JSON Object" in {
       val obj = json"""{"a":1,"b":{"c":2},"d":null}"""
-
       obj.flattenedKeySet(".", ignoreNull = true) === Set("a", "b.c")
       obj.flattenedKeySet(".", ignoreNull = false) === Set("a", "b.c", "d")
       obj.flattenedKeySet("/", ignoreNull = true) === Set("a", "b/c")
 
       1.asJson.flattenedKeySet() === Set.empty
+      json"""{}""".flattenedKeySet() === Set.empty
+      json"""[{"a":1}]""".flattenedKeySet() === Set.empty
     }
 
     "provide a method to get the key-value set of a JSON Object" in {
       val obj = json"""{"a":1,"b":{"c":2},"d":null}"""
-
       obj.flattenedKeyValueSet(".") === Set(("a", Json.fromInt(1)), ("b.c", Json.fromInt(2)), ("d", Json.Null))
       obj.flattenedKeyValueSet("/") === Set(("a", Json.fromInt(1)), ("b/c", Json.fromInt(2)), ("d", Json.Null))
 
       1.asJson.flattenedKeyValueSet() === Set.empty
+      json"""{}""".flattenedKeyValueSet() === Set.empty
+      json"""[{"a":1}]""".flattenedKeyValueSet() === Set.empty
     }
 
     "provide a method to get a field from a JSON object" in {


### PR DESCRIPTION
Tries to improve the performance of the `flattenedKeyValueSet` method.
As we are working with JSON document mapped to a `JsonObject` type, I think it is safe for an auxiliary method to not use Sets. Additionally, this PR proposes using builders for the data Vector and path strings.


<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

### Does this change relate to existing issues or pull requests?
N/A
<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?
No.
<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?
I did some ad-hoc "benchmarks" and this seems about 4 times faster with the JSON I used:

```
val now = System.currentTimeMillis()
(0 to 50000).foreach(_ => testJson.flattenedKeySet("."))
println(s"Took ${System.currentTimeMillis() - now}")
```

<details>

<summary>Example JSON used</summary>

```
{
  "sectionA": {
    "level1": {
      "description": "Section A, level 1",
      "info": {
        "level2": {
          "dataPoint": "Something A2",
          "context": {
            "level3": {
              "identifier": "A3-ID",
              "properties": {
                "level4": {
                  "status": "active",
                  "details": {
                    "level5": {
                      "creator": "System A",
                      "audit": {
                        "level6": {
                          "timestamp": "2025-01-01T00:00:00Z",
                          "trace": {
                            "level7": {
                              "hash": "abc123xyz",
                              "verification": {
                                "level8": {
                                  "verifiedBy": "ServiceA",
                                  "method": {
                                    "level9": {
                                      "type": "automated",
                                      "notes": {
                                        "level10": {
                                          "description": "Verified automatically via script",
                                          "reviewed": "pending"
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "sectionB": {
    "level1": {
      "description": "Section B, level 1",
      "info": {
        "level2": {
          "dataPoint": "Something B2",
          "context": {
            "level3": {
              "identifier": "B3-ID",
              "properties": {
                "level4": {
                  "status": "pending",
                  "details": {
                    "level5": {
                      "creator": "System B",
                      "audit": {
                        "level6": {
                          "timestamp": "2025-02-02T12:34:56Z",
                          "trace": {
                            "level7": {
                              "hash": "def456uvw",
                              "verification": {
                                "level8": {
                                  "verifiedBy": "ServiceB",
                                  "method": {
                                    "level9": {
                                      "type": "manual",
                                      "notes": {
                                        "level10": {
                                          "description": "Checked by quality control",
                                          "reviewed": "approved"
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "sectionC": {
    "level1": {
      "description": "Section C, level 1",
      "info": {
        "level2": {
          "dataPoint": "Something C2",
          "context": {
            "level3": {
              "identifier": "C3-ID",
              "properties": {
                "level4": {
                  "status": "inactive",
                  "details": {
                    "level5": {
                      "creator": "System C",
                      "audit": {
                        "level6": {
                          "timestamp": "2025-03-03T03:03:03Z",
                          "trace": {
                            "level7": {
                              "hash": "ghi789rst",
                              "verification": {
                                "level8": {
                                  "verifiedBy": "ServiceC",
                                  "method": {
                                    "level9": {
                                      "type": "hybrid",
                                      "notes": {
                                        "level10": {
                                          "description": "Automated followed by manual confirmation",
                                          "reviewed": "approved"
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "sectionD": {
    "level1": {
      "description": "Section D, level 1",
      "info": {
        "level2": {
          "dataPoint": "Something D2",
          "context": {
            "level3": {
              "identifier": "D3-ID",
              "properties": {
                "level4": {
                  "status": "archived",
                  "details": {
                    "level5": {
                      "creator": "System D",
                      "audit": {
                        "level6": {
                          "timestamp": "2025-04-04T04:44:44Z",
                          "trace": {
                            "level7": {
                              "hash": "jkl012mno",
                              "verification": {
                                "level8": {
                                  "verifiedBy": "ServiceD",
                                  "method": {
                                    "level9": {
                                      "type": "manual",
                                      "notes": {
                                        "level10": {
                                          "description": "Archived data, final check done",
                                          "reviewed": "complete"
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  },
  "sectionE": {
    "level1": {
      "description": "Section E, level 1",
      "info": {
        "level2": {
          "dataPoint": "Something E2",
          "context": {
            "level3": {
              "identifier": "E3-ID",
              "properties": {
                "level4": {
                  "status": "testing",
                  "details": {
                    "level5": {
                      "creator": "System E",
                      "audit": {
                        "level6": {
                          "timestamp": "2025-05-05T05:55:55Z",
                          "trace": {
                            "level7": {
                              "hash": "mno345pqr",
                              "verification": {
                                "level8": {
                                  "verifiedBy": "ServiceE",
                                  "method": {
                                    "level9": {
                                      "type": "automated",
                                      "notes": {
                                        "level10": {
                                          "description": "Early test environment verification",
                                          "reviewed": "in-progress"
                                        }
                                      }
                                    }
                                  }
                                }
                              }
                            }
                          }
                        }
                      }
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}

```

</details> 
<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
