### PR TITLE
Add `implementation` method to `apso-caching` config class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ## [0.22.0] - 2025-04-23
 
 This release includes full support for Scala 3, now that `apso-caching` is ported. `apso-caching`'s API has breaking
-changes; check the [README](/README.md) for the updated documentation.
+changes; check the [README](README.md) for the updated documentation.
 
 In addition, the performance of the `flattenedKeyValueSet` in `apso-circe` was improved.
 

--- a/README.md
+++ b/README.md
@@ -363,13 +363,8 @@ import scala.concurrent.duration._
 
 import com.kevel.apso.caching._
 
-val conf = config.Cache(Some(5.seconds), None)
-// conf: config.Cache = Cache(
-//   timeToLive = Some(value = 5 seconds),
-//   maximumSize = None
-// )
-val cache = conf.implementation[String, Int]
-// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@10f2706a)
+val cache = config.Cache(Some(5.seconds), None).implementation[String, Int]
+// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@7f262c77)
 
 val x1 = cache.getIfPresent("requests")
 // x1: Option[Int] = None

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ The `SerializableAWSCredentials` class provides a serializable container for AWS
 
 ## Caching
 
-The `apso-caching` module provides provides utilities for caching, using `Caffeine` as the underlying implementation.
+The `apso-caching` module provides utilities for caching, using `Caffeine` as the underlying implementation.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
@@ -369,7 +369,7 @@ val conf = config.Cache(Some(5.seconds), None)
 //   maximumSize = None
 // )
 val cache = conf.implementation[String, Int]
-// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@3260516c)
+// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@10f2706a)
 
 val x1 = cache.getIfPresent("requests")
 // x1: Option[Int] = None

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ import scala.concurrent.duration._
 import com.kevel.apso.caching._
 
 val cache = config.Cache(Some(5.seconds), None).implementation[String, Int]
-// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@7f262c77)
+// cache: com.github.blemale.scaffeine.Cache[String, Int]
 
 val x1 = cache.getIfPresent("requests")
 // x1: Option[Int] = None
@@ -397,11 +397,11 @@ val cachedFn = ((i: Int) => {
 // cachedFn: SyncMemoizeFn1[Int, Int] = <function1>
 
 cachedFn(2)
-// res27: Int = 0
+// res26: Int = 0
 cachedFn(2)
-// res28: Int = 0
+// res27: Int = 0
 x
-// res29: AtomicInteger = 2
+// res28: AtomicInteger = 2
 
 val y = new AtomicInteger(0)
 // y: AtomicInteger = 3
@@ -413,11 +413,11 @@ val cachedFutFn = ((i: Int) => Future {
 // cachedFutFn: AsyncMemoizeFn1[Int, Int] = <function1>
 
 Await.result(cachedFutFn(3), Duration.Inf)
-// res30: Int = 0
+// res29: Int = 0
 Await.result(cachedFutFn(3), Duration.Inf)
-// res31: Int = 0
+// res30: Int = 0
 y
-// res32: AtomicInteger = 3
+// res31: AtomicInteger = 3
 ```
 
 ## Collections
@@ -491,13 +491,13 @@ val nt = t.set("one", 1).set("two", 2).set("three", 3).set("four", 4)
 // ...
 
 nt.get("one")
-// res34: Option[Int] = Some(value = 1)
+// res33: Option[Int] = Some(value = 1)
 
 nt.get("two")
-// res35: Option[Int] = Some(value = 2)
+// res34: Option[Int] = Some(value = 2)
 
 nt.get("five")
-// res36: Option[Int] = None
+// res35: Option[Int] = None
 ```
 
 ### TypedMap
@@ -511,25 +511,25 @@ val m = TypedMap("one", 2, 3L)
 // m: TypedMap[Any] = Map(java.lang.String -> one, Int -> 2, Long -> 3)
 
 m[String]
-// res38: String = "one"
+// res37: String = "one"
 
 m[Int]
-// res39: Int = 2
+// res38: Int = 2
 
 m[Long]
-// res40: Long = 3L
+// res39: Long = 3L
 
 m.get[String]
-// res41: Option[String] = Some(value = "one")
+// res40: Option[String] = Some(value = "one")
 
 m.get[Int]
-// res42: Option[Int] = Some(value = 2)
+// res41: Option[Int] = Some(value = 2)
 
 m.get[Long]
-// res43: Option[Long] = Some(value = 3L)
+// res42: Option[Long] = Some(value = 3L)
 
 m.get[Char]
-// res44: Option[Char] = None
+// res43: Option[Char] = None
 ```
 
 ### Iterators
@@ -547,7 +547,7 @@ val circularIterator = CircularIterator(List(1, 2, 3).iterator)
 // circularIterator: CircularIterator[Int] = non-empty iterator
 
 circularIterator.take(10).toList
-// res46: List[Int] = List(1, 2, 3, 1, 2, 3, 1, 2, 3, 1)
+// res45: List[Int] = List(1, 2, 3, 1, 2, 3, 1, 2, 3, 1)
 ```
 
 #### MergedBufferedIterator
@@ -565,7 +565,7 @@ val it1 = MergedBufferedIterator(List(
 // it1: MergedBufferedIterator[Int] = empty iterator
 
 it1.toList
-// res48: List[Int] = List(
+// res47: List[Int] = List(
 //   0,
 //   0,
 //   0,
@@ -615,7 +615,7 @@ val it2 = MergedBufferedIterator(List(
 // it2: MergedBufferedIterator[Int] = non-empty iterator
 
 it2.mergeSorted(Iterator(4, 6).buffered).toList
-// res49: List[Int] = List(1, 2, 3, 4, 5, 6)
+// res48: List[Int] = List(1, 2, 3, 4, 5, 6)
 ```
 
 ## Encryption
@@ -658,10 +658,10 @@ libraryDependencies += "com.kevel" %% "apso-hashing" % "0.21.1"
 import com.kevel.apso.hashing.Implicits._
 
 "abcd".md5
-// res52: String = "e2fc714c4727ee9395f324cd2e7f331f"
+// res51: String = "e2fc714c4727ee9395f324cd2e7f331f"
 
 "abcd".murmurHash
-// res53: Long = 7785666560123423118L
+// res52: Long = 7785666560123423118L
 ```
 
 ## IO
@@ -746,7 +746,7 @@ val js2 = Json.obj(
 ```
 ```scala
 js1.deepMerge(js2).spaces2
-// res58: String = """{
+// res57: String = """{
 //   "c" : 4,
 //   "d" : {
 //     "e" : 5,
@@ -762,7 +762,7 @@ fromFullPaths(Seq(
    "b.d" -> 3.asJson,
    "e" -> "xpto".asJson,
    "f.g.h" -> 5.asJson)).spaces2
-// res59: String = """{
+// res58: String = """{
 //   "f" : {
 //     "g" : {
 //       "h" : 5
@@ -777,26 +777,26 @@ fromFullPaths(Seq(
 // }"""
 
 js1.getField[Int]("a")
-// res60: Option[Int] = Some(value = 2)
+// res59: Option[Int] = Some(value = 2)
 js1.getField[Int]("d.f")
-// res61: Option[Int] = Some(value = 6)
+// res60: Option[Int] = Some(value = 6)
 js1.getField[Int]("x")
-// res62: Option[Int] = None
+// res61: Option[Int] = None
 
 js1.deleteField("a")
-// res63: Json = JObject(
+// res62: Json = JObject(
 //   value = object[b -> 3,d -> {
 //   "f" : 6
 // }]
 // )
 js1.deleteField("d.f")
-// res64: Json = JObject(
+// res63: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
 //   
 // }]
 // )
 js1.deleteField("x")
-// res65: Json = JObject(
+// res64: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
 //   "f" : 6
 // }]
@@ -810,13 +810,13 @@ The `JsonConvert` object contains helpers for converting between JSON values and
 import com.kevel.apso.circe._
 
 JsonConvert.toJson("abcd")
-// res67: io.circe.Json = JString(value = "abcd")
+// res66: io.circe.Json = JString(value = "abcd")
 
 JsonConvert.toJson(1)
-// res68: io.circe.Json = JNumber(value = JsonLong(value = 1L))
+// res67: io.circe.Json = JNumber(value = JsonLong(value = 1L))
 
 JsonConvert.toJson(Map(1 -> 2, 3 -> 4))
-// res69: io.circe.Json = JObject(value = object[1 -> 2,3 -> 4])
+// res68: io.circe.Json = JObject(value = object[1 -> 2,3 -> 4])
 ```
 
 ## Profiling
@@ -857,10 +857,10 @@ import com.kevel.apso.time._
 import com.kevel.apso.time.Implicits._
 
 (new DateTime("2012-01-01") to new DateTime("2012-01-01")).toList
-// res71: List[DateTime] = List(2012-01-01T00:00:00.000Z)
+// res70: List[DateTime] = List(2012-01-01T00:00:00.000Z)
 
 (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.day)
-// res72: IterableInterval = IndexedSeq(
+// res71: IterableInterval = IndexedSeq(
 //   2012-02-01T00:00:00.000Z,
 //   2012-02-02T00:00:00.000Z,
 //   2012-02-03T00:00:00.000Z,
@@ -893,7 +893,7 @@ import com.kevel.apso.time.Implicits._
 // )
 
 (new DateTime("2012-01-01") until new DateTime("2012-02-01") by 2.minutes)
-// res73: IterableInterval = IndexedSeq(
+// res72: IterableInterval = IndexedSeq(
 //   2012-01-01T00:00:00.000Z,
 //   2012-01-01T00:02:00.000Z,
 //   2012-01-01T00:04:00.000Z,

--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ The `S3Bucket` class wraps an instance of `AmazonS3Client` (from AWS SDK for Jav
 The `SerializableAWSCredentials` class provides a serializable container for AWS credentials, extending the `AWSCredentials` class (from AWS SDK for Java).
 
 ## Caching
-The `apso-caching` module provides provides utilities for caching.
+
+The `apso-caching` module provides provides utilities for caching, using `Caffeine` as the underlying implementation.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
@@ -355,9 +356,32 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "0.21.1"
 ```
 
-Apso provides utilities to simplify the caching of method calls, using `Caffeine` as the underlying implementation.
+The simplest use case is bootstrapping a cache implementation based on a configuration object:
 
-These utilities are provided as `cachedSync()` and `cachedAsync()` extension methods over all `FunctionN[]` types:
+```scala
+import scala.concurrent.duration._
+
+import com.kevel.apso.caching._
+
+val conf = config.Cache(Some(5.seconds), None)
+// conf: config.Cache = Cache(
+//   timeToLive = Some(value = 5 seconds),
+//   maximumSize = None
+// )
+val cache = conf.implementation[String, Int]
+// cache: com.github.blemale.scaffeine.Cache[String, Int] = Cache(com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalManualCache@3260516c)
+
+val x1 = cache.getIfPresent("requests")
+// x1: Option[Int] = None
+
+cache.put("requests", 1)
+
+val x2 = cache.getIfPresent("requests")
+// x2: Option[Int] = Some(value = 1)
+```
+
+Apso also provides utilities to simplify the caching of method calls. These utilities are provided as `cachedSync()` and
+`cachedAsync()` extension methods over all `FunctionN[]` types:
 
 ```scala
 import scala.concurrent._
@@ -378,11 +402,11 @@ val cachedFn = ((i: Int) => {
 // cachedFn: SyncMemoizeFn1[Int, Int] = <function1>
 
 cachedFn(2)
-// res25: Int = 0
+// res27: Int = 0
 cachedFn(2)
-// res26: Int = 0
+// res28: Int = 0
 x
-// res27: AtomicInteger = 2
+// res29: AtomicInteger = 2
 
 val y = new AtomicInteger(0)
 // y: AtomicInteger = 3
@@ -394,11 +418,11 @@ val cachedFutFn = ((i: Int) => Future {
 // cachedFutFn: AsyncMemoizeFn1[Int, Int] = <function1>
 
 Await.result(cachedFutFn(3), Duration.Inf)
-// res28: Int = 0
+// res30: Int = 0
 Await.result(cachedFutFn(3), Duration.Inf)
-// res29: Int = 0
+// res31: Int = 0
 y
-// res30: AtomicInteger = 3
+// res32: AtomicInteger = 3
 ```
 
 ## Collections
@@ -472,13 +496,13 @@ val nt = t.set("one", 1).set("two", 2).set("three", 3).set("four", 4)
 // ...
 
 nt.get("one")
-// res32: Option[Int] = Some(value = 1)
+// res34: Option[Int] = Some(value = 1)
 
 nt.get("two")
-// res33: Option[Int] = Some(value = 2)
+// res35: Option[Int] = Some(value = 2)
 
 nt.get("five")
-// res34: Option[Int] = None
+// res36: Option[Int] = None
 ```
 
 ### TypedMap
@@ -492,25 +516,25 @@ val m = TypedMap("one", 2, 3L)
 // m: TypedMap[Any] = Map(java.lang.String -> one, Int -> 2, Long -> 3)
 
 m[String]
-// res36: String = "one"
+// res38: String = "one"
 
 m[Int]
-// res37: Int = 2
+// res39: Int = 2
 
 m[Long]
-// res38: Long = 3L
+// res40: Long = 3L
 
 m.get[String]
-// res39: Option[String] = Some(value = "one")
+// res41: Option[String] = Some(value = "one")
 
 m.get[Int]
-// res40: Option[Int] = Some(value = 2)
+// res42: Option[Int] = Some(value = 2)
 
 m.get[Long]
-// res41: Option[Long] = Some(value = 3L)
+// res43: Option[Long] = Some(value = 3L)
 
 m.get[Char]
-// res42: Option[Char] = None
+// res44: Option[Char] = None
 ```
 
 ### Iterators
@@ -528,7 +552,7 @@ val circularIterator = CircularIterator(List(1, 2, 3).iterator)
 // circularIterator: CircularIterator[Int] = non-empty iterator
 
 circularIterator.take(10).toList
-// res44: List[Int] = List(1, 2, 3, 1, 2, 3, 1, 2, 3, 1)
+// res46: List[Int] = List(1, 2, 3, 1, 2, 3, 1, 2, 3, 1)
 ```
 
 #### MergedBufferedIterator
@@ -546,7 +570,7 @@ val it1 = MergedBufferedIterator(List(
 // it1: MergedBufferedIterator[Int] = empty iterator
 
 it1.toList
-// res46: List[Int] = List(
+// res48: List[Int] = List(
 //   0,
 //   0,
 //   0,
@@ -596,7 +620,7 @@ val it2 = MergedBufferedIterator(List(
 // it2: MergedBufferedIterator[Int] = non-empty iterator
 
 it2.mergeSorted(Iterator(4, 6).buffered).toList
-// res47: List[Int] = List(1, 2, 3, 4, 5, 6)
+// res49: List[Int] = List(1, 2, 3, 4, 5, 6)
 ```
 
 ## Encryption
@@ -639,10 +663,10 @@ libraryDependencies += "com.kevel" %% "apso-hashing" % "0.21.1"
 import com.kevel.apso.hashing.Implicits._
 
 "abcd".md5
-// res50: String = "e2fc714c4727ee9395f324cd2e7f331f"
+// res52: String = "e2fc714c4727ee9395f324cd2e7f331f"
 
 "abcd".murmurHash
-// res51: Long = 7785666560123423118L
+// res53: Long = 7785666560123423118L
 ```
 
 ## IO
@@ -727,7 +751,7 @@ val js2 = Json.obj(
 ```
 ```scala
 js1.deepMerge(js2).spaces2
-// res56: String = """{
+// res58: String = """{
 //   "c" : 4,
 //   "d" : {
 //     "e" : 5,
@@ -743,7 +767,7 @@ fromFullPaths(Seq(
    "b.d" -> 3.asJson,
    "e" -> "xpto".asJson,
    "f.g.h" -> 5.asJson)).spaces2
-// res57: String = """{
+// res59: String = """{
 //   "f" : {
 //     "g" : {
 //       "h" : 5
@@ -758,26 +782,26 @@ fromFullPaths(Seq(
 // }"""
 
 js1.getField[Int]("a")
-// res58: Option[Int] = Some(value = 2)
+// res60: Option[Int] = Some(value = 2)
 js1.getField[Int]("d.f")
-// res59: Option[Int] = Some(value = 6)
+// res61: Option[Int] = Some(value = 6)
 js1.getField[Int]("x")
-// res60: Option[Int] = None
+// res62: Option[Int] = None
 
 js1.deleteField("a")
-// res61: Json = JObject(
+// res63: Json = JObject(
 //   value = object[b -> 3,d -> {
 //   "f" : 6
 // }]
 // )
 js1.deleteField("d.f")
-// res62: Json = JObject(
+// res64: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
 //   
 // }]
 // )
 js1.deleteField("x")
-// res63: Json = JObject(
+// res65: Json = JObject(
 //   value = object[a -> 2,b -> 3,d -> {
 //   "f" : 6
 // }]
@@ -791,13 +815,13 @@ The `JsonConvert` object contains helpers for converting between JSON values and
 import com.kevel.apso.circe._
 
 JsonConvert.toJson("abcd")
-// res65: io.circe.Json = JString(value = "abcd")
+// res67: io.circe.Json = JString(value = "abcd")
 
 JsonConvert.toJson(1)
-// res66: io.circe.Json = JNumber(value = JsonLong(value = 1L))
+// res68: io.circe.Json = JNumber(value = JsonLong(value = 1L))
 
 JsonConvert.toJson(Map(1 -> 2, 3 -> 4))
-// res67: io.circe.Json = JObject(value = object[1 -> 2,3 -> 4])
+// res69: io.circe.Json = JObject(value = object[1 -> 2,3 -> 4])
 ```
 
 ## Profiling
@@ -838,10 +862,10 @@ import com.kevel.apso.time._
 import com.kevel.apso.time.Implicits._
 
 (new DateTime("2012-01-01") to new DateTime("2012-01-01")).toList
-// res69: List[DateTime] = List(2012-01-01T00:00:00.000Z)
+// res71: List[DateTime] = List(2012-01-01T00:00:00.000Z)
 
 (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.day)
-// res70: IterableInterval = IndexedSeq(
+// res72: IterableInterval = IndexedSeq(
 //   2012-02-01T00:00:00.000Z,
 //   2012-02-02T00:00:00.000Z,
 //   2012-02-03T00:00:00.000Z,
@@ -874,7 +898,7 @@ import com.kevel.apso.time.Implicits._
 // )
 
 (new DateTime("2012-01-01") until new DateTime("2012-02-01") by 2.minutes)
-// res71: IterableInterval = IndexedSeq(
+// res73: IterableInterval = IndexedSeq(
 //   2012-01-01T00:00:00.000Z,
 //   2012-01-01T00:02:00.000Z,
 //   2012-01-01T00:04:00.000Z,

--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,7 @@ lazy val docs = (project in file("apso-docs"))
     mdocOut := (ThisBuild / baseDirectory).value,
 
     mdocVariables := Map(
+      // TODO: Update this to the latest version.
       "VERSION" -> "0.21.1" // This version should be set to the currently released version.
     ),
 

--- a/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
+++ b/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
@@ -1,7 +1,5 @@
 package com.kevel.apso.caching
 
-import com.github.blemale.scaffeine.Scaffeine
-
 import com.github.blemale.scaffeine.{AsyncLoadingCache, LoadingCache}
 
 import scala.concurrent.Future
@@ -17,7 +15,7 @@ import MemoizeFn._
 sealed trait SyncMemoizeFn0[V] extends (() => V) {
   protected def cacheConfig: config.Cache
   protected def fn: Unit => V
-  private lazy val cache: LoadingCache[Unit, V] = MemoizeFn.builder(cacheConfig).build(fn)
+  private lazy val cache: LoadingCache[Unit, V] = cacheConfig.build.build(fn)
   override def apply(): V = cache.get(())
 }
 
@@ -30,7 +28,7 @@ sealed trait SyncMemoizeFn0[V] extends (() => V) {
 sealed trait AsyncMemoizeFn0[V] extends (() => Future[V]) {
   protected def cacheConfig: config.Cache
   protected def fn: Unit => Future[V]
-  private lazy val cache: AsyncLoadingCache[Unit, V] = MemoizeFn.builder(cacheConfig).buildAsyncFuture(fn)
+  private lazy val cache: AsyncLoadingCache[Unit, V] = cacheConfig.build.buildAsyncFuture(fn)
   override def apply(): Future[V] = cache.get(())
 }
 
@@ -44,7 +42,7 @@ sealed trait AsyncMemoizeFn0[V] extends (() => Future[V]) {
 sealed trait SyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], V] {
   def cacheConfig: config.Cache
   def fn: ([#I0#]) => V
-  private lazy val cache: LoadingCache[([#I0#]), V] = MemoizeFn.builder(cacheConfig).build(fn.tupled)
+  private lazy val cache: LoadingCache[([#I0#]), V] = cacheConfig.build.build(fn.tupled)
   override def apply([#i0: I0#]): V = cache.get(([#i0#]))
 }#
 ]
@@ -59,18 +57,12 @@ sealed trait SyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], V] {
 sealed trait AsyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], Future[V]] {
   def cacheConfig: config.Cache
   def fn: ([#I0#]) => Future[V]
-  private lazy val cache: AsyncLoadingCache[([#I0#]), V] = MemoizeFn.builder(cacheConfig).buildAsyncFuture(fn.tupled)
+  private lazy val cache: AsyncLoadingCache[([#I0#]), V] = cacheConfig.build.buildAsyncFuture(fn.tupled)
   override def apply([#i0: I0#]): Future[V] = cache.get(([#i0#]))
 }#
 ]
 
 object MemoizeFn {
-  private[caching] def builder(conf: config.Cache): Scaffeine[Any, Any] = {
-    val withSize = conf.maximumSize.fold(Scaffeine())(Scaffeine().maximumSize)
-    val withTimeToLive = conf.timeToLive.fold(withSize)(withSize.expireAfterWrite)
-    withTimeToLive
-  }
-
   private[caching] implicit class Function1Ops[A, B](f: A => B) {
     def tupled: A => B = f
   }

--- a/caching/src/main/scala/com/kevel/apso/caching/config/Cache.scala
+++ b/caching/src/main/scala/com/kevel/apso/caching/config/Cache.scala
@@ -2,6 +2,9 @@ package com.kevel.apso.caching.config
 
 import scala.concurrent.duration.FiniteDuration
 
+import com.github.blemale.scaffeine
+import com.github.blemale.scaffeine.Scaffeine
+
 /** A cache configuration for the underlying [[https://github.com/ben-manes/caffeine Caffeine]] cache implementation.
   *
   * @param timeToLive
@@ -11,4 +14,22 @@ import scala.concurrent.duration.FiniteDuration
   *   the maximum number of entries in the cache. Note that this threshold might be temporarily exceeded while the
   *   underlying cache is evicting old entries.
   */
-case class Cache(timeToLive: Option[FiniteDuration], maximumSize: Option[Long])
+case class Cache(timeToLive: Option[FiniteDuration], maximumSize: Option[Long]) {
+  private[caching] def build: Scaffeine[Any, Any] = {
+    val withSize = maximumSize.fold(Scaffeine())(Scaffeine().maximumSize)
+    val withTimeToLive = timeToLive.fold(withSize)(withSize.expireAfterWrite)
+    withTimeToLive
+  }
+
+  /** A [[com.github.blemale.scaffeine.Scaffeine]] cache implementation for this configuration. Use this over the
+    * [[com.kevel.apso.caching.CachedFunctionsExtras]] if you need finer-grained control over cache insertions.
+    *
+    * @tparam K
+    *   the key type.
+    * @tparam V
+    *   the value type.
+    * @return
+    *   a [[com.github.blemale.scaffeine.Scaffeine]] cache implementation.
+    */
+  def implementation[K, V]: scaffeine.Cache[K, V] = build.build()
+}

--- a/caching/src/test/scala/com/kevel/apso/caching/config/CacheSpec.scala
+++ b/caching/src/test/scala/com/kevel/apso/caching/config/CacheSpec.scala
@@ -1,0 +1,19 @@
+package com.kevel.apso.caching.config
+
+import scala.concurrent.duration.DurationInt
+
+import org.specs2.mutable.Specification
+
+class CacheSpec extends Specification {
+  "A Cache configuration instance" should {
+    "provide an `implementation` method that exposes a configured `Scaffeine` implementation" in {
+      val cache = Cache(Some(500.millis), None).implementation[String, String]
+      cache.getIfPresent("john") === None
+      cache.put("john", "doe")
+      cache.getIfPresent("john") === Some("doe")
+      eventually(10, 100.millis)(cache.getIfPresent("john") === None)
+      cache.put("john", "rivers")
+      cache.getIfPresent("john") === Some("rivers")
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -341,18 +341,21 @@ libraryDependencies += "com.kevel" %% "apso-caching" % "@VERSION@"
 
 The simplest use case is bootstrapping a cache implementation based on a configuration object:
 
-```scala mdoc:reset
+```scala mdoc:compile-only
 import scala.concurrent.duration._
 
 import com.kevel.apso.caching._
 
 val cache = config.Cache(Some(5.seconds), None).implementation[String, Int]
+// cache: com.github.blemale.scaffeine.Cache[String, Int]
 
 val x1 = cache.getIfPresent("requests")
+// x1: Option[Int] = None
 
 cache.put("requests", 1)
 
 val x2 = cache.getIfPresent("requests")
+// x2: Option[Int] = Some(value = 1)
 ```
 
 Apso also provides utilities to simplify the caching of method calls. These utilities are provided as `cachedSync()` and

--- a/docs/README.md
+++ b/docs/README.md
@@ -330,7 +330,8 @@ The `S3Bucket` class wraps an instance of `AmazonS3Client` (from AWS SDK for Jav
 The `SerializableAWSCredentials` class provides a serializable container for AWS credentials, extending the `AWSCredentials` class (from AWS SDK for Java).
 
 ## Caching
-The `apso-caching` module provides provides utilities for caching.
+
+The `apso-caching` module provides provides utilities for caching, using `Caffeine` as the underlying implementation.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
@@ -338,9 +339,25 @@ To use it in an existing SBT project, add the following dependency to your `buil
 libraryDependencies += "com.kevel" %% "apso-caching" % "@VERSION@"
 ```
 
-Apso provides utilities to simplify the caching of method calls, using `Caffeine` as the underlying implementation.
+The simplest use case is bootstrapping a cache implementation based on a configuration object:
 
-These utilities are provided as `cachedSync()` and `cachedAsync()` extension methods over all `FunctionN[]` types:
+```scala mdoc:reset
+import scala.concurrent.duration._
+
+import com.kevel.apso.caching._
+
+val conf = config.Cache(Some(5.seconds), None)
+val cache = conf.implementation[String, Int]
+
+val x1 = cache.getIfPresent("requests")
+
+cache.put("requests", 1)
+
+val x2 = cache.getIfPresent("requests")
+```
+
+Apso also provides utilities to simplify the caching of method calls. These utilities are provided as `cachedSync()` and
+`cachedAsync()` extension methods over all `FunctionN[]` types:
 
 ```scala mdoc:reset
 import scala.concurrent._

--- a/docs/README.md
+++ b/docs/README.md
@@ -331,7 +331,7 @@ The `SerializableAWSCredentials` class provides a serializable container for AWS
 
 ## Caching
 
-The `apso-caching` module provides provides utilities for caching, using `Caffeine` as the underlying implementation.
+The `apso-caching` module provides utilities for caching, using `Caffeine` as the underlying implementation.
 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -346,8 +346,7 @@ import scala.concurrent.duration._
 
 import com.kevel.apso.caching._
 
-val conf = config.Cache(Some(5.seconds), None)
-val cache = conf.implementation[String, Int]
+val cache = config.Cache(Some(5.seconds), None).implementation[String, Int]
 
 val x1 = cache.getIfPresent("requests")
 


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

Adds a useful `implementation` method to `apso-caching` that exposes a raw `Scaffeine` implementation with a matching configuration. This will make advanced downstream usages simpler and more consistent.

This should not break binary compatibility.

### Does this change relate to existing issues or pull requests?

Related to #815.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

Yes, it was updated accordingly.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

New spec.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
