### PR TITLE
Prepare v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ In addition, the performance of the `flattenedKeyValueSet` in `apso-circe` was i
 - Start cross-compiling apso-caching to Scala 3 ([#827](https://github.com/adzerk/apso/pull/827)).
 
 ### Changed
-- Remove LruCache ([#818](https://github.com/adzerk/apso/pull/818)).
 - Update sbt-mdoc to 2.7.0 ([#822](https://github.com/adzerk/apso/pull/822)).
 - Use builders and avoid Sets in flattenedKeyValueSet ([#825](https://github.com/adzerk/apso/pull/825)).
 - Avoid specifying a default value for the maximum cache size ([#826](https://github.com/adzerk/apso/pull/826)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ### Security
 -->
 
+## [0.22.1] - 2025-04-30
+
+This release reintroduces the `config.Cache.implementation` method in `apso-caching`, now typed in both the cache key
+and value and returning a `Scaffeine` instance. This should make lower-level cache usages easier.
+
+### Added
+- Add `implementation` method to `apso-caching` config class ([#833](https://github.com/adzerk/apso/pull/833)).
+
+### Fixed
+- Fix non-determinism in CachedFunctionExtrasSpec failure eviction ([#832](https://github.com/adzerk/apso/pull/832)).
+
+[0.22.1]: https://github.com/adzerk/apso/compare/v0.22.0...v0.22.1
+
 ## [0.22.0] - 2025-04-23
 
 This release includes full support for Scala 3, now that `apso-caching` is ported. `apso-caching`'s API has breaking
@@ -26,12 +39,10 @@ changes; check the [README](README.md) for the updated documentation.
 In addition, the performance of the `flattenedKeyValueSet` in `apso-circe` was improved.
 
 ### Added
-
 - Port `apso-caching` to Scaffeine ([#821](https://github.com/adzerk/apso/pull/821)).
 - Start cross-compiling apso-caching to Scala 3 ([#827](https://github.com/adzerk/apso/pull/827)).
 
 ### Changed
-
 - Remove LruCache ([#818](https://github.com/adzerk/apso/pull/818)).
 - Update sbt-mdoc to 2.7.0 ([#822](https://github.com/adzerk/apso/pull/822)).
 - Use builders and avoid Sets in flattenedKeyValueSet ([#825](https://github.com/adzerk/apso/pull/825)).
@@ -41,7 +52,6 @@ In addition, the performance of the `flattenedKeyValueSet` in `apso-circe` was i
 - Update circe-core, circe-generic, ... to 0.14.13 ([#830](https://github.com/adzerk/apso/pull/830)).
 
 ### Removed
-
 - Remove LruCache ([#818](https://github.com/adzerk/apso/pull/818)).
 - Remove `scala-collection-compat` dependency listing ([#824](https://github.com/adzerk/apso/pull/824)).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Apso's latest release is built against Scala 2.13 and Scala 3.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso" % "0.22.1"
 ```
 
 The project is divided in modules, you can instead install only a specific module.
@@ -19,7 +19,7 @@ The project is divided in modules, you can instead install only a specific modul
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-testkit" % "0.21.1" % "test"
+libraryDependencies += "com.kevel" %% "apso-testkit" % "0.22.1" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.
@@ -69,7 +69,7 @@ Please take into account that the library is still in an experimental stage and 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-core" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-core" % "0.22.1"
 ```
 
 ### Config
@@ -283,7 +283,7 @@ The `pekko-http` module provides additional [directives](https://pekko.apache.or
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-pekko-http" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-pekko-http" % "0.22.1"
 ```
 
 ### ClientIPDirectives
@@ -305,7 +305,7 @@ Apso provides a group of classes to ease the interaction with the Amazon Web Ser
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-aws" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-aws" % "0.22.1"
 ```
 
 ### ConfigCredentialsProvider
@@ -353,7 +353,7 @@ The `apso-caching` module provides utilities for caching, using `Caffeine` as th
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-caching" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-caching" % "0.22.1"
 ```
 
 The simplest use case is bootstrapping a cache implementation based on a configuration object:
@@ -425,7 +425,7 @@ y
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-collections" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-collections" % "0.22.1"
 ```
 
 ### Trie
@@ -626,7 +626,7 @@ creation of the underlying Cyphers.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-encryption" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-encryption" % "0.22.1"
 ```
 
 The following shows the creation of `Encryptor` and `Decryptor` objects,
@@ -651,7 +651,7 @@ decryptor.get.decryptToString(encryptor.get.encryptToSafeString(secretData).get)
 Apso provides utilities for various hashing functions. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-hashing" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-hashing" % "0.22.1"
 ```
 
 ```scala
@@ -671,7 +671,7 @@ Apso provides methods to deal with IO-related features in the `io` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-io" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-io" % "0.22.1"
 ```
 
 ### FileDescriptor
@@ -714,7 +714,7 @@ ResourceUtil.getResourceAsString("reference.conf")
 Apso includes a bunch of utilities to work with JSON serialization and deserialization, specifically with the [circe](https://circe.github.io/circe/) library. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-circe" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-circe" % "0.22.1"
 ```
 
 ### ExtraJsonProtocol
@@ -826,7 +826,7 @@ The `profiling` module of apso provides utilities to help with profiling the run
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-profiling" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-profiling" % "0.22.1"
 ```
 
 ### CpuSampler
@@ -844,7 +844,7 @@ The `apso-time` module provides utilities to work with `DateTime` and `LocalDate
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-time" % "0.21.1"
+libraryDependencies += "com.kevel" %% "apso-time" % "0.22.1"
 ```
 
 See the following sample usages:

--- a/build.sbt
+++ b/build.sbt
@@ -187,8 +187,7 @@ lazy val docs = (project in file("apso-docs"))
     mdocOut := (ThisBuild / baseDirectory).value,
 
     mdocVariables := Map(
-      // TODO: Update this to the latest version.
-      "VERSION" -> "0.21.1" // This version should be set to the currently released version.
+      "VERSION" -> "0.22.1" // This version should be set to the currently released version.
     ),
 
     publish / skip := true


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

As titled; proposes releasing a patch to bring back `Cache.implementation`.

### Does this change relate to existing issues or pull requests?

Motivated by #833.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

Yes.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

N/A.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
