### PR TITLE
Remove `nscala-time` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ### Security
 -->
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+- Dependency on `nscala-time`, using only `joda.time` methods instead ([#849](https://github.com/adzerk/apso/pull/849)).
+
+### Fixed
+
+### Security
+
 ## [0.22.1] - 2025-04-30
 
 This release reintroduces the `config.Cache.implementation` method in `apso-caching`, now typed in both the cache key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,21 +18,6 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ### Security
 -->
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-- Dependency on `nscala-time`, using only `joda.time` methods instead ([#849](https://github.com/adzerk/apso/pull/849)).
-
-### Fixed
-
-### Security
-
 ## [0.22.1] - 2025-04-30
 
 This release reintroduces the `config.Cache.implementation` method in `apso-caching`, now typed in both the cache key

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ libraryDependencies += "com.kevel" %% "apso-time" % "0.22.1"
 See the following sample usages:
 
 ```scala
-import com.github.nscala_time.time.Imports._
+import org.joda.time.{DateTime, Period}
 
 import com.kevel.apso.time._
 
@@ -859,7 +859,7 @@ import com.kevel.apso.time.Implicits._
 (new DateTime("2012-01-01") to new DateTime("2012-01-01")).toList
 // res70: List[DateTime] = List(2012-01-01T00:00:00.000Z)
 
-(new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.day)
+(new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.days(1))
 // res71: IterableInterval = IndexedSeq(
 //   2012-02-01T00:00:00.000Z,
 //   2012-02-02T00:00:00.000Z,
@@ -892,7 +892,7 @@ import com.kevel.apso.time.Implicits._
 //   2012-02-29T00:00:00.000Z
 // )
 
-(new DateTime("2012-01-01") until new DateTime("2012-02-01") by 2.minutes)
+(new DateTime("2012-01-01") until new DateTime("2012-02-01") by Period.minutes(2))
 // res72: IterableInterval = IndexedSeq(
 //   2012-01-01T00:00:00.000Z,
 //   2012-01-01T00:02:00.000Z,

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val testkit = module(project, "testkit")
   )
 
 lazy val time = module(project, "time")
-  .settings(libraryDependencies ++= Seq(JodaTime, NscalaTime, Specs2Core % Test))
+  .settings(libraryDependencies ++= Seq(JodaTime, Specs2Core % Test))
 
 lazy val apso = (project in file("."))
   .settings(commonSettings: _*)

--- a/docs/README.md
+++ b/docs/README.md
@@ -669,7 +669,7 @@ libraryDependencies += "com.kevel" %% "apso-time" % "@VERSION@"
 See the following sample usages:
 
 ```scala mdoc:reset
-import com.github.nscala_time.time.Imports._
+import org.joda.time.{DateTime, Period}
 
 import com.kevel.apso.time._
 
@@ -677,9 +677,9 @@ import com.kevel.apso.time.Implicits._
 
 (new DateTime("2012-01-01") to new DateTime("2012-01-01")).toList
 
-(new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.day)
+(new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.days(1))
 
-(new DateTime("2012-01-01") until new DateTime("2012-02-01") by 2.minutes)
+(new DateTime("2012-01-01") until new DateTime("2012-02-01") by Period.minutes(2))
 ```
 
 ## TestKit

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,6 @@ object Dependencies {
     val FastMd5        = "2.7.1"
     val JUnit          = "4.13.2"
     val JodaTime       = "2.14.0"
-    val NscalaTime     = "3.0.0"
     val ScalaCheck     = "1.18.1"
     val ScalaLogging   = "3.9.5"
     val ScalaPool      = "0.4.3"
@@ -42,7 +41,6 @@ object Dependencies {
   val FastMd5                = "com.joyent.util"             % "fast-md5"                  % Versions.FastMd5
   val JUnit                  = "junit"                       % "junit"                     % Versions.JUnit
   val JodaTime               = "joda-time"                   % "joda-time"                 % Versions.JodaTime
-  val NscalaTime             = "com.github.nscala-time"     %% "nscala-time"               % Versions.NscalaTime
   val PekkoActor             = "org.apache.pekko"           %% "pekko-actor"               % Versions.Pekko
   val PekkoActorTestkitTyped = "org.apache.pekko"           %% "pekko-actor-testkit-typed" % Versions.Pekko
   val PekkoActorTyped        = "org.apache.pekko"           %% "pekko-actor-typed"         % Versions.Pekko

--- a/time/src/main/scala/com/kevel/apso/time/Implicits.scala
+++ b/time/src/main/scala/com/kevel/apso/time/Implicits.scala
@@ -47,7 +47,8 @@ object Implicits {
     def to(d2: LocalDate) =
       LocalDateInterval(
         IterableInterval(
-          new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay.plusMillis(1)),
+          d1.toDateTimeAtStartOfDay,
+          d2.toDateTimeAtStartOfDay.plusMillis(1),
           Period.days(1)
         )
       )
@@ -63,7 +64,8 @@ object Implicits {
     def until(d2: LocalDate) =
       LocalDateInterval(
         IterableInterval(
-          new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay),
+          d1.toDateTimeAtStartOfDay,
+          d2.toDateTimeAtStartOfDay,
           Period.days(1)
         )
       )
@@ -114,7 +116,7 @@ object Implicits {
       *   with a 1 day step.
       */
     def to(d2: DateTime): IterableInterval =
-      IterableInterval(new Interval(d1, d2.plusMillis(1)), Period.days(1))
+      IterableInterval(d1, d2.plusMillis(1), Period.days(1))
 
     /** Returns an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime`
       * (exclusive), with a 1 day step.
@@ -124,7 +126,7 @@ object Implicits {
       *   an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime` (exclusive),
       *   with a 1 day step.
       */
-    def until(d2: DateTime): IterableInterval = IterableInterval(new Interval(d1, d2), Period.days(1))
+    def until(d2: DateTime): IterableInterval = IterableInterval(d1, d2, Period.days(1))
   }
 
   /** Implicit class that provides new methods for `ReadableIntervals`.

--- a/time/src/main/scala/com/kevel/apso/time/Implicits.scala
+++ b/time/src/main/scala/com/kevel/apso/time/Implicits.scala
@@ -46,7 +46,10 @@ object Implicits {
       */
     def to(d2: LocalDate) =
       LocalDateInterval(
-        IterableInterval(new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay), Period.days(1), true)
+        IterableInterval(
+          new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay.plusMillis(1)),
+          Period.days(1)
+        )
       )
 
     /** Returns an iterable interval starting at this `LocalDate` (inclusive) and ending at the given `LocalDate`
@@ -59,7 +62,10 @@ object Implicits {
       */
     def until(d2: LocalDate) =
       LocalDateInterval(
-        IterableInterval(new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay), Period.days(1), false)
+        IterableInterval(
+          new Interval(d1.toDateTimeAtStartOfDay, d2.toDateTimeAtStartOfDay),
+          Period.days(1)
+        )
       )
   }
 
@@ -108,7 +114,7 @@ object Implicits {
       *   with a 1 day step.
       */
     def to(d2: DateTime): IterableInterval =
-      IterableInterval(new Interval(d1, d2), Period.days(1), true)
+      IterableInterval(new Interval(d1, d2.plusMillis(1)), Period.days(1))
 
     /** Returns an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime`
       * (exclusive), with a 1 day step.
@@ -118,7 +124,7 @@ object Implicits {
       *   an iterable interval starting at this `DateTime` (inclusive) and ending at the given `DateTime` (exclusive),
       *   with a 1 day step.
       */
-    def until(d2: DateTime): IterableInterval = IterableInterval(new Interval(d1, d2), Period.days(1), false)
+    def until(d2: DateTime): IterableInterval = IterableInterval(new Interval(d1, d2), Period.days(1))
   }
 
   /** Implicit class that provides new methods for `ReadableIntervals`.
@@ -139,7 +145,7 @@ object Implicits {
       else {
         val q = (interval.toDuration.getMillis / n).toInt
         (0 until n).map { i =>
-          new Interval(interval.getStart.plus(q * i + i), (interval.getStart.plus(q * (i + 1)).plus(i)))
+          new Interval(interval.getStart.plus(q * i), (interval.getStart.plus(q * (i + 1))))
         }
       }
     }

--- a/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
+++ b/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
@@ -1,7 +1,6 @@
 package com.kevel.apso.time
 
-import com.github.nscala_time.time.Imports._
-import org.joda.time.ReadableInterval
+import org.joda.time.{DateTime, Interval, LocalDate, Period, ReadableInterval}
 
 /** A view of a time interval as an indexed sequence of `DateTimes`.
   */
@@ -29,17 +28,17 @@ trait IterableInterval extends IndexedSeq[DateTime] {
 case class SteppedInterval(interval: ReadableInterval, step: Period) extends IterableInterval {
 
   lazy val length: Int = {
-    var i = (interval.toDurationMillis / step.toDurationFrom(interval.getStart).millis).toInt
-    if (apply(i) < interval.getEnd) {
-      while (apply(i) <= interval.getEnd) { i += 1 }
+    var i = (interval.toDurationMillis / step.toDurationFrom(interval.getStart).getMillis).toInt
+    if (apply(i).isBefore(interval.getEnd)) {
+      while (!apply(i).isAfter(interval.getEnd)) { i += 1 }
       i
     } else {
-      while (apply(i) > interval.getEnd) { i -= 1 }
+      while (apply(i).isAfter(interval.getEnd)) { i -= 1 }
       i + 1
     } // FIXME more intelligent code for this?
   }
 
-  def apply(idx: Int) = interval.getStart + step.multipliedBy(idx)
+  def apply(idx: Int) = interval.getStart.plus(step.multipliedBy(idx))
 
   def by(newStep: Period) = new SteppedInterval(interval, newStep)
 }
@@ -71,8 +70,8 @@ object IterableInterval {
     */
   def apply(interval: ReadableInterval, step: Period, lastInclusive: Boolean = true): IterableInterval =
     if (lastInclusive) SteppedInterval(interval, step)
-    else if (interval.millis == 0) EmptySteppedInterval(step)
-    else SteppedInterval(interval.getStart to interval.getEnd - 1.millis, step)
+    else if (interval.toDuration.getMillis == 0) EmptySteppedInterval(step)
+    else SteppedInterval(new Interval(interval.getStart, interval.getEnd.minusMillis(1)), step)
 }
 
 /** A view of a time interval as an indexed sequence of `LocalDate`.

--- a/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
+++ b/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
@@ -1,6 +1,6 @@
 package com.kevel.apso.time
 
-import org.joda.time.{DateTime, Interval, LocalDate, Period, ReadableInterval}
+import org.joda.time.{DateTime, LocalDate, Period, ReadableInterval}
 
 /** A view of a time interval as an indexed sequence of `DateTimes`.
   */
@@ -30,10 +30,10 @@ case class SteppedInterval(interval: ReadableInterval, step: Period) extends Ite
   lazy val length: Int = {
     var i = (interval.toDurationMillis / step.toDurationFrom(interval.getStart).getMillis).toInt
     if (apply(i).isBefore(interval.getEnd)) {
-      while (!apply(i).isAfter(interval.getEnd)) { i += 1 }
+      while (apply(i).isBefore(interval.getEnd)) { i += 1 }
       i
     } else {
-      while (apply(i).isAfter(interval.getEnd)) { i -= 1 }
+      while (!apply(i).isBefore(interval.getEnd)) { i -= 1 }
       i + 1
     } // FIXME more intelligent code for this?
   }
@@ -63,15 +63,12 @@ object IterableInterval {
     *   the `ReadableInterval` to view as an indexed sequence
     * @param step
     *   the period of time between consecutive `DateTimes`
-    * @param lastInclusive
-    *   `true` if the upper bound of the interval is to be included in the sequence
     * @return
     *   an iterable time interval with the given step.
     */
-  def apply(interval: ReadableInterval, step: Period, lastInclusive: Boolean = true): IterableInterval =
-    if (lastInclusive) SteppedInterval(interval, step)
-    else if (interval.toDuration.getMillis == 0) EmptySteppedInterval(step)
-    else SteppedInterval(new Interval(interval.getStart, interval.getEnd.minusMillis(1)), step)
+  def apply(interval: ReadableInterval, step: Period): IterableInterval =
+    if (interval.toDuration.getMillis == 0) EmptySteppedInterval(step)
+    else SteppedInterval(interval, step)
 }
 
 /** A view of a time interval as an indexed sequence of `LocalDate`.

--- a/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
+++ b/time/src/main/scala/com/kevel/apso/time/IterableInterval.scala
@@ -1,6 +1,6 @@
 package com.kevel.apso.time
 
-import org.joda.time.{DateTime, LocalDate, Period, ReadableInterval}
+import org.joda.time.{DateTime, Interval, LocalDate, Period, ReadableInstant, ReadableInterval}
 
 /** A view of a time interval as an indexed sequence of `DateTimes`.
   */
@@ -69,6 +69,19 @@ object IterableInterval {
   def apply(interval: ReadableInterval, step: Period): IterableInterval =
     if (interval.toDuration.getMillis == 0) EmptySteppedInterval(step)
     else SteppedInterval(interval, step)
+
+  /** Creates a new iterable time interval from `start` (inclusive) to `end` (exclusive).
+    * @param start
+    *   the first `ReadableInstant` of the interval, the first element of the indexed sequence
+    * @param end
+    *   the last exclusive `ReadableInstant` of the interval, the first element not in the sequence
+    * @param step
+    *   the period of time between consecutive `DateTimes`
+    * @return
+    *   an iterable time interval with the given step.
+    */
+  def apply(start: ReadableInstant, end: ReadableInstant, step: Period): IterableInterval =
+    IterableInterval(new Interval(start, end), step)
 }
 
 /** A view of a time interval as an indexed sequence of `LocalDate`.

--- a/time/src/test/scala/com/kevel/apso/time/ImplicitsSpec.scala
+++ b/time/src/test/scala/com/kevel/apso/time/ImplicitsSpec.scala
@@ -101,11 +101,11 @@ class ImplicitsSpec extends Specification {
 
   "An ApsoTimeInterval" should {
     "split itself into subsequences" in {
-      val interval = new Interval(0, 99)
+      val interval = new Interval(0, 100)
       interval.split(0) === Seq.empty
       interval.split(-1) must throwAn[IllegalArgumentException]
       interval.split(5).size === 5
-      interval.split(4) === Seq(new Interval(0, 24), new Interval(25, 49), new Interval(50, 74), new Interval(75, 99))
+      interval.split(4) === Seq(new Interval(0, 25), new Interval(25, 50), new Interval(50, 75), new Interval(75, 100))
     }
   }
 }

--- a/time/src/test/scala/com/kevel/apso/time/ImplicitsSpec.scala
+++ b/time/src/test/scala/com/kevel/apso/time/ImplicitsSpec.scala
@@ -1,6 +1,6 @@
 package com.kevel.apso.time
 
-import com.github.nscala_time.time.Imports._
+import org.joda.time.{DateTime, DateTimeZone, Interval, LocalDate, LocalDateTime, Period}
 import org.specs2.mutable._
 
 import Implicits._
@@ -8,38 +8,38 @@ import Implicits._
 class ImplicitsSpec extends Specification {
   "An ApsoTimeLocalDate" should {
     "support range creation" in {
-      val startDate = "2014-01-01".toLocalDate
-      val endDate = "2014-01-03".toLocalDate
+      val startDate = new LocalDate("2014-01-01")
+      val endDate = new LocalDate("2014-01-03")
 
       (startDate to endDate) === IndexedSeq(
-        "2014-01-01".toLocalDate,
-        "2014-01-02".toLocalDate,
-        "2014-01-03".toLocalDate
+        new LocalDate("2014-01-01"),
+        new LocalDate("2014-01-02"),
+        new LocalDate("2014-01-03")
       )
 
-      (startDate until endDate) === IndexedSeq("2014-01-01".toLocalDate, "2014-01-02".toLocalDate)
+      (startDate until endDate) === IndexedSeq(new LocalDate("2014-01-01"), new LocalDate("2014-01-02"))
 
-      (startDate until "2014-01-06".toLocalDate by 2.days) === IndexedSeq(
-        "2014-01-01".toLocalDate,
-        "2014-01-03".toLocalDate,
-        "2014-01-05".toLocalDate
+      (startDate until new LocalDate("2014-01-06") by Period.days(2)) === IndexedSeq(
+        new LocalDate("2014-01-01"),
+        new LocalDate("2014-01-03"),
+        new LocalDate("2014-01-05")
       )
     }
 
     "support conversion to UTC DateTime" in {
-      val utcDateTime = "2014-01-01".toLocalDate.utcDateTime
+      val utcDateTime = new LocalDate("2014-01-01").utcDateTime
 
       utcDateTime === new DateTime(2014, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)
     }
 
     "support conversion to DateTime at the end of day" in {
-      val dateTime = "2014-01-01".toLocalDate.toDateTimeAtEndOfDay
+      val dateTime = new LocalDate("2014-01-01").toDateTimeAtEndOfDay
 
       dateTime === new DateTime(2014, 1, 1, 23, 59, 59, 999)
     }
 
     "support conversion to DateTime at the end of day (with target timezone)" in {
-      val dateTime = "2014-01-01".toLocalDate.toDateTimeAtEndOfDay(DateTimeZone.forID("EST"))
+      val dateTime = new LocalDate("2014-01-01").toDateTimeAtEndOfDay(DateTimeZone.forID("EST"))
 
       dateTime === new DateTime(2014, 1, 1, 23, 59, 59, 999, DateTimeZone.forID("EST"))
     }
@@ -58,7 +58,7 @@ class ImplicitsSpec extends Specification {
     }
 
     "support conversion to UTC LocalDate" in {
-      val localDate = "2014-01-01".toLocalDate
+      val localDate = new LocalDate("2014-01-01")
       val dateTime = localDate.toDateTimeAtStartOfDay.toDateTime(DateTimeZone.forID("EST"))
       val estLocalDate = dateTime.toLocalDate
       val utcLocalDate = dateTime.utcLocalDate
@@ -68,9 +68,9 @@ class ImplicitsSpec extends Specification {
     }
 
     "support same day comparison" in {
-      val dateTimeStart = "2014-01-01".toLocalDate.toDateTimeAtStartOfDay
-      val dateTimeEnd = "2014-01-01".toLocalDate.toDateTimeAtEndOfDay
-      val dateTimeOther = "2014-01-02".toLocalDate.toDateTimeAtStartOfDay
+      val dateTimeStart = new LocalDate("2014-01-01").toDateTimeAtStartOfDay
+      val dateTimeEnd = new LocalDate("2014-01-01").toDateTimeAtEndOfDay
+      val dateTimeOther = new LocalDate("2014-01-02").toDateTimeAtStartOfDay
 
       dateTimeStart.isSameDay(dateTimeEnd) must beTrue
       dateTimeOther.isSameDay(dateTimeEnd) must beFalse
@@ -78,9 +78,9 @@ class ImplicitsSpec extends Specification {
     }
 
     "be able to check if a date time is between two date times" in {
-      val dateTimeStart = "2014-01-01".toLocalDate.toDateTimeAtStartOfDay
-      val dateTimeEnd = "2014-01-01".toLocalDate.toDateTimeAtEndOfDay
-      val dateTimeOther = "2014-01-02".toLocalDate.toDateTimeAtStartOfDay
+      val dateTimeStart = new LocalDate("2014-01-01").toDateTimeAtStartOfDay
+      val dateTimeEnd = new LocalDate("2014-01-01").toDateTimeAtEndOfDay
+      val dateTimeOther = new LocalDate("2014-01-02").toDateTimeAtStartOfDay
 
       dateTimeStart.between(dateTimeEnd, dateTimeOther) must beFalse
       dateTimeEnd.between(dateTimeStart, dateTimeOther) must beTrue
@@ -88,10 +88,10 @@ class ImplicitsSpec extends Specification {
     }
 
     "support iterable interval creation" in {
-      val dateTime1Start = "2014-01-01".toLocalDate.toDateTimeAtStartOfDay
-      val dateTime2Start = "2014-01-02".toLocalDate.toDateTimeAtStartOfDay
-      val dateTime3Start = "2014-01-03".toLocalDate.toDateTimeAtStartOfDay
-      val dateTime3End = "2014-01-03".toLocalDate.toDateTimeAtEndOfDay
+      val dateTime1Start = new LocalDate("2014-01-01").toDateTimeAtStartOfDay
+      val dateTime2Start = new LocalDate("2014-01-02").toDateTimeAtStartOfDay
+      val dateTime3Start = new LocalDate("2014-01-03").toDateTimeAtStartOfDay
+      val dateTime3End = new LocalDate("2014-01-03").toDateTimeAtEndOfDay
 
       dateTime1Start.until(dateTime3Start).toList === List(dateTime1Start, dateTime2Start)
       dateTime1Start.until(dateTime3End).toList === List(dateTime1Start, dateTime2Start, dateTime3Start)

--- a/time/src/test/scala/com/kevel/apso/time/IterableIntervalSpec.scala
+++ b/time/src/test/scala/com/kevel/apso/time/IterableIntervalSpec.scala
@@ -1,6 +1,6 @@
 package com.kevel.apso.time
 
-import com.github.nscala_time.time.Imports._
+import org.joda.time.{DateTime, Period}
 import org.specs2.mutable._
 
 import Implicits._
@@ -21,16 +21,20 @@ class IterableIntervalSpec extends Specification {
     }
 
     "return the appropriate length with other steps" in {
-      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.day).length mustEqual 29
+      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.days(1)).length mustEqual 29
 
-      (new DateTime("2012-01-01") until new DateTime("2012-02-01") by 1.month).length mustEqual 1
-      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.month).length mustEqual 1
+      (new DateTime("2012-01-01") until new DateTime("2012-02-01") by Period.months(1)).length mustEqual 1
+      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.months(1)).length mustEqual 1
 
-      (new DateTime("2012-01-01") until new DateTime("2012-02-01") by 2.minutes).length mustEqual 31 * 24 * 60 / 2
-      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 2.minutes).length mustEqual 29 * 24 * 60 / 2
+      (new DateTime("2012-01-01") until new DateTime("2012-02-01") by Period.minutes(
+        2
+      )).length mustEqual 31 * 24 * 60 / 2
+      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.minutes(
+        2
+      )).length mustEqual 29 * 24 * 60 / 2
 
-      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by 1.year).length mustEqual 1
-      (new DateTime("2012-02-01") to new DateTime("2012-03-01") by 1.year).length mustEqual 1
+      (new DateTime("2012-02-01") until new DateTime("2012-03-01") by Period.years(1)).length mustEqual 1
+      (new DateTime("2012-02-01") to new DateTime("2012-03-01") by Period.years(1)).length mustEqual 1
     }
 
     "return the correct values while iterating with the default step" in {
@@ -53,12 +57,12 @@ class IterableIntervalSpec extends Specification {
     }
 
     "return the correct values while iterating with other steps" in {
-      (new DateTime("2012-01-01") until new DateTime("2012-01-01") by 1.day).toSeq mustEqual Seq()
+      (new DateTime("2012-01-01") until new DateTime("2012-01-01") by Period.days(1)).toSeq mustEqual Seq()
 
-      (new DateTime("2012-01-01") until new DateTime("2012-01-03") by 2.days).toSeq mustEqual
+      (new DateTime("2012-01-01") until new DateTime("2012-01-03") by Period.days(2)).toSeq mustEqual
         Seq(new DateTime("2012-01-01"))
 
-      (new DateTime(2012, 1, 29, 1, 0) until new DateTime(2012, 1, 29, 1, 10) by 2.minutes).toSeq mustEqual
+      (new DateTime(2012, 1, 29, 1, 0) until new DateTime(2012, 1, 29, 1, 10) by Period.minutes(2)).toSeq mustEqual
         Seq(
           new DateTime(2012, 1, 29, 1, 0),
           new DateTime(2012, 1, 29, 1, 2),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.22.1"
+ThisBuild / version := "0.22.2-SNAPSHOT"


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->
We don't make much use of the dependency and removing it avoids polluting downstream projects using `apso-time`. I also added a `to` method to `DateTime` similar to `LocalDate`'s, as that method is provided by `nscala-time`, and this allows downstream dependencies to have access to this when just using `joda`.

### Does this change relate to existing issues or pull requests?

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->
Is a first step towards #823 and to help downstream projects migrate more incrementally.

### Does this change require an update to the documentation?

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->
Yes, updated the README accordingly and added a changelog entry for this.

### How has this been tested?

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
Unit tests.