### PR TITLE
Change deprecated sonatype snapshots repo definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -208,8 +208,8 @@ lazy val docs = (project in file("apso-docs"))
 lazy val commonSettings = Seq(
   // format: off
   resolvers ++=
-    Resolver.sonatypeOssRepos("snapshots") ++
       Seq(
+        Resolver.sonatypeCentralSnapshots,
         Resolver.typesafeRepo("snapshots"),
         "Spray Repository"                  at  "https://repo.spray.io/",
         "Bintray Scalaz Releases"           at  "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->
We had the following deprecation warning in the build:
```
apso/build.sbt:211: warning: method sonatypeOssRepos in class ResolverFunctions is deprecated (since 1.11.2): Sonatype OSS Repository Hosting (OSSRH) will be sunset on 2025-06-30; use the following instead:
  resolvers += Resolver.sonatypeCentralSnapshots
    Resolver.sonatypeOssRepos("snapshots") ++
```

This PR replaces the deprecated snapshots repo as instructed.

### Does this change relate to existing issues or pull requests?

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->
No.

### Does this change require an update to the documentation?

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->
No.

### How has this been tested?

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
I checked that the warning no longer appears. I haven't checked the snapshots publishing as I copied the replacement from the warning...