### PR TITLE
Add testkit module for `specs2` v5

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,6 +1,6 @@
 version = 3.9.7
 
-runner.dialect = scala213source3
+runner.dialect = scala3
 maxColumn = 120
 newlines.topLevelStatementBlankLines = [
   { blanks: { after: 0 } }

--- a/README.md
+++ b/README.md
@@ -951,4 +951,16 @@ Apso comes with a TestKit with extra useful matchers for [specs2](https://etorre
 
 * `CustomMatchers`: provides a matcher to check if an object is serializable and one to check if a file exists;
 * `FutureExtraMatchers`: provides extra matchers for futures and implicit conversions for awaitables;
-* `JreVersionTestHelper`: provides a wrapper for `AsResult` to only run a spec if a specific JRE version is satisfied;
+* `JreVersionTestHelper`: provides a wrapper for `AsResult` to only run a spec if a specific JRE version is satisfied.
+
+To use the version for version 4 of `specs2`, add the following dependency to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.kevel" %% "apso-testkit" % "0.23.0"
+```
+
+To use the version for version 5 of `specs2` (only available for Scala 3), add the following dependency to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.kevel" %% "apso-testkit-specs2-5" % "0.23.0"
+```

--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,7 @@ lazy val aws = module(project, "aws")
       AwsJavaSdkS3,
       AwsJavaSdkCore,
       ScalaLogging,
-      TypesafeConfig,
-      Specs2Core % Test
+      TypesafeConfig
     )
   )
 
@@ -153,6 +152,18 @@ lazy val testkit = module(project, "testkit")
     )
   )
 
+lazy val testkitSpecs2_5 = module(project, "testkit-specs2-5")
+  .settings(
+    scalaVersion       := Versions.Scala3,
+    crossScalaVersions := List(Versions.Scala3),
+    libraryDependencies ++= Seq(
+      ScalaTestCore,
+      Specs2Common_5  % Provided,
+      Specs2Core_5    % Provided,
+      Specs2Matcher_5 % Provided
+    )
+  )
+
 lazy val time = module(project, "time")
   .settings(libraryDependencies ++= Seq(JodaTime, Specs2Core % Test))
 
@@ -186,6 +197,7 @@ lazy val apso = (project in file("."))
     pekkoHttp,
     profiling,
     testkit,
+    testkitSpecs2_5,
     time
   )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -688,4 +688,16 @@ Apso comes with a TestKit with extra useful matchers for [specs2](https://etorre
 
 * `CustomMatchers`: provides a matcher to check if an object is serializable and one to check if a file exists;
 * `FutureExtraMatchers`: provides extra matchers for futures and implicit conversions for awaitables;
-* `JreVersionTestHelper`: provides a wrapper for `AsResult` to only run a spec if a specific JRE version is satisfied;
+* `JreVersionTestHelper`: provides a wrapper for `AsResult` to only run a spec if a specific JRE version is satisfied.
+
+To use the version for version 4 of `specs2`, add the following dependency to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.kevel" %% "apso-testkit" % "@VERSION@"
+```
+
+To use the version for version 5 of `specs2` (only available for Scala 3), add the following dependency to your `build.sbt`:
+
+```scala
+libraryDependencies += "com.kevel" %% "apso-testkit-specs2-5" % "@VERSION@"
+```

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,6 +21,7 @@ object Dependencies {
     val ScalaTest      = "3.2.19"
     val SimpleJmx      = "2.2"
     val Specs2         = "4.21.0"
+    val Specs2_5       = "5.6.3"
     val Squants        = "1.8.3"
     val SshJ           = "0.40.0"
     val TypesafeConfig = "1.4.3"
@@ -56,9 +57,12 @@ object Dependencies {
   val ScalaTestCore          = "org.scalatest"              %% "scalatest-core"            % Versions.ScalaTest
   val SimpleJmx              = "com.j256.simplejmx"          % "simplejmx"                 % Versions.SimpleJmx
   val Specs2Common           = "org.specs2"                 %% "specs2-common"             % Versions.Specs2
+  val Specs2Common_5         = "org.specs2"                 %% "specs2-common"             % Versions.Specs2_5
   val Specs2Core             = "org.specs2"                 %% "specs2-core"               % Versions.Specs2
+  val Specs2Core_5           = "org.specs2"                 %% "specs2-core"               % Versions.Specs2_5
   val Specs2JUnit            = "org.specs2"                 %% "specs2-junit"              % Versions.Specs2
   val Specs2Matcher          = "org.specs2"                 %% "specs2-matcher"            % Versions.Specs2
+  val Specs2Matcher_5        = "org.specs2"                 %% "specs2-matcher"            % Versions.Specs2_5
   val Specs2ScalaCheck       = "org.specs2"                 %% "specs2-scalacheck"         % Versions.Specs2
   val Squants                = "org.typelevel"              %% "squants"                   % Versions.Squants
   val SshJ                   = "com.hierynomus"              % "sshj"                      % Versions.SshJ

--- a/testkit-specs2-5/src/main/scala/com/kevel/apso/AdditionalIsEmpty.scala
+++ b/testkit-specs2-5/src/main/scala/com/kevel/apso/AdditionalIsEmpty.scala
@@ -1,0 +1,22 @@
+package com.kevel.apso
+
+import org.specs2.collection.IsEmpty
+
+trait AdditionalIsEmpty {
+  given mapIsEmpty[K, V]: IsEmpty[Map[K, V]] with {
+    def isEmpty(t: Map[K, V]): Boolean =
+      t.isEmpty
+  }
+
+  given mutMapIsEmpty[K, V]: IsEmpty[scala.collection.mutable.Map[K, V]] with {
+    def isEmpty(t: scala.collection.mutable.Map[K, V]): Boolean =
+      t.isEmpty
+  }
+
+  given setIsEmpty[T]: IsEmpty[Set[T]] with {
+    def isEmpty(t: Set[T]): Boolean =
+      t.isEmpty
+  }
+}
+
+object AdditionalIsEmpty extends AdditionalIsEmpty

--- a/testkit-specs2-5/src/main/scala/com/kevel/apso/CustomMatchers.scala
+++ b/testkit-specs2-5/src/main/scala/com/kevel/apso/CustomMatchers.scala
@@ -1,0 +1,32 @@
+package com.kevel.apso
+
+import java.io._
+
+import scala.reflect.ClassTag
+
+import org.specs2.execute.{NoDetails, Result}
+import org.specs2.matcher.{Expectable, Matcher}
+import org.specs2.mutable.SpecificationLike
+
+trait CustomMatchers extends SpecificationLike {
+  def serializationBufSize = 10000
+
+  def beSerializable[T <: AnyRef: ClassTag]: Matcher[T] = (obj: T) => {
+    val buffer = new ByteArrayOutputStream(serializationBufSize)
+
+    val out = new ObjectOutputStream(buffer)
+    out.writeObject(obj) must
+      (not(throwA[NotSerializableException]) and not(throwAn[InvalidClassException]))
+  }
+
+  def exist: Matcher[File] = new Matcher[File] {
+    def apply[S <: File](v: Expectable[S]) = {
+      Result.result(v.value.exists(), v.value.getName + " exists", v.value.getName + " does not exist", v.toString)
+    }
+  }
+
+  /** Return a successful MatchResult[T]. This is useful to explicitly expose a value outside a Matcher which can later
+    * be accessed with `_.expectable.value`.
+    */
+  def offer[T](result: T): Result = Result.result(test = true, "ok", result.toString, NoDetails)
+}

--- a/testkit-specs2-5/src/main/scala/com/kevel/apso/FutureExtraMatchers.scala
+++ b/testkit-specs2-5/src/main/scala/com/kevel/apso/FutureExtraMatchers.scala
@@ -1,0 +1,30 @@
+package com.kevel.apso
+
+import scala.concurrent._
+import scala.concurrent.duration._
+
+import org.specs2.execute.AsResult
+import org.specs2.matcher._
+import org.specs2.mutable.SpecificationLike
+
+trait FutureExtraMatchers { this: SpecificationLike =>
+
+  implicit class RichAwaitable[T](val awaitable: Awaitable[T]) {
+    def get = Await.result(awaitable, 1.second)
+    def await(timeout: Duration) = Await.result(awaitable, timeout)
+  }
+
+  implicit class RichFutureExtraMatcher[T: AsResult](m: => T) {
+
+    /** @return
+      *   a matcher that needs to eventually match, after a given number of retries.
+      */
+    def eventually(retries: Int): T = EventuallyMatchers.eventually(retries, 100.milliseconds)(m)
+  }
+
+  def beEventually[T: AsResult](f: => T): T =
+    eventually(40, 200.milliseconds)(f)
+
+  def beEventually[T: AsResult](retries: Int, sleep: FiniteDuration)(f: => T): T =
+    eventually(retries, sleep)(f)
+}

--- a/testkit-specs2-5/src/main/scala/com/kevel/apso/JceTestHelper.scala
+++ b/testkit-specs2-5/src/main/scala/com/kevel/apso/JceTestHelper.scala
@@ -1,0 +1,15 @@
+package com.kevel.apso
+
+import javax.crypto.Cipher
+
+import org.specs2.execute.{AsResult, Result, Skipped}
+
+object JceTestHelper {
+
+  /** Ensures the Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files are installed.
+    */
+  def unlimitedJCE[T](r: => T)(implicit evidence: AsResult[T]): Result = {
+    if (Cipher.getMaxAllowedKeyLength("sha256") == Int.MaxValue) evidence.asResult(r)
+    else Skipped("Java Cryptography Extension Unlimited Strength Jurisdiction Policy Files not installed.")
+  }
+}

--- a/testkit-specs2-5/src/main/scala/com/kevel/apso/JreVersionTestHelper.scala
+++ b/testkit-specs2-5/src/main/scala/com/kevel/apso/JreVersionTestHelper.scala
@@ -1,0 +1,20 @@
+package com.kevel.apso
+
+import scala.math.Ordering.Implicits._
+
+import org.specs2.execute.{AsResult, Result, Skipped}
+
+import JreVersionTestHelper._
+
+trait JreVersionTestHelper {
+  def jre[T](major: Int, minor: Int)(r: => T)(implicit evidence: AsResult[T]): Result = {
+    System.getProperty("java.version") match {
+      case VersionRegex(ma, mi) if (ma.toInt, mi.toInt) >= (major, minor) => evidence.asResult(r)
+      case _ => Skipped(s"This test requires JRE >= $major.$minor")
+    }
+  }
+}
+
+object JreVersionTestHelper extends JreVersionTestHelper {
+  val VersionRegex = """^([\d]+)\.([\d]+).*$""".r
+}

--- a/testkit/src/main/scala/com/kevel/apso/CustomMatchers.scala
+++ b/testkit/src/main/scala/com/kevel/apso/CustomMatchers.scala
@@ -16,9 +16,6 @@ trait CustomMatchers extends SpecificationLike {
     val out = new ObjectOutputStream(buffer)
     out.writeObject(obj) must
       not(throwA[NotSerializableException]) and not(throwAn[InvalidClassException])
-    // val in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray))
-    // in.readObject() must beAnInstanceOf[T] and
-    //   not(throwA[InvalidClassException]) and not(throwA[StreamCorruptedException])
   }
 
   def exist: Matcher[File] = new Matcher[File] {


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->
This PR proposes adding a new module to provide the same `specs2` helpers for its v5. The new module approach is meant to allow downstream users to keep using `apso` with both v4 or v5 as they choose.

I am not sure on the module name, let me know if you think of better ones 😄 

### Does this change relate to existing issues or pull requests?

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->
No.

### Does this change require an update to the documentation?

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->
I updated the README, detailing the availability of `testkit` modules for both versions of `specs2`.

### How has this been tested?

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
I have tried this in a project that I am migrating to `specs2` v5 and everything worked.