### PR TITLE
Fix the build definition for release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import spray.boilerplate.BoilerplatePlugin
 ThisBuild / organization := "com.kevel"
 
 ThisBuild / scalaVersion       := Versions.Scala213
-ThisBuild / crossScalaVersions := List(Versions.Scala213, Versions.Scala3)
+ThisBuild / crossScalaVersions := Nil
 
 val javaVersion = "11"
 
@@ -13,10 +13,11 @@ val javaVersion = "11"
 // and scala-xml 2.x are "mostly" binary compatible.
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-def module(project: Project, moduleName: String) =
+def module(project: Project, moduleName: String, crossScala: List[String] = List(Versions.Scala213, Versions.Scala3)) =
   (project in file(moduleName))
     .settings(name := s"apso-$moduleName")
     .settings(commonSettings: _*)
+    .settings(crossScalaVersions := crossScala)
 
 lazy val aws = module(project, "aws")
   .dependsOn(core)
@@ -152,7 +153,7 @@ lazy val specs2_4 = module(project, "specs2_4")
     )
   )
 
-lazy val specs2_5 = module(project, "specs2_5")
+lazy val specs2_5 = module(project, "specs2_5", List(Versions.Scala3))
   .settings(
     scalaVersion       := Versions.Scala3,
     crossScalaVersions := List(Versions.Scala3),
@@ -166,9 +167,7 @@ lazy val specs2_5 = module(project, "specs2_5")
 lazy val time = module(project, "time")
   .settings(libraryDependencies ++= Seq(JodaTime, Specs2_4Core % Test))
 
-lazy val apso = (project in file("."))
-  .settings(commonSettings: _*)
-  .settings(name := "apso")
+lazy val docs = (project in file("apso-docs"))
   .dependsOn(
     aws,
     caching,
@@ -181,30 +180,13 @@ lazy val apso = (project in file("."))
     pekko,
     pekkoHttp,
     profiling,
-    time
-  )
-  .aggregate(
-    aws,
-    caching,
-    circe,
-    collections,
-    core,
-    encryption,
-    hashing,
-    io,
-    pekko,
-    pekkoHttp,
-    profiling,
     specs2_4,
-    specs2_5,
     time
   )
-
-lazy val docs = (project in file("apso-docs"))
-  .dependsOn(apso)
   .settings(commonSettings: _*)
   .settings(
     // format: off
+    crossScalaVersions := List(Versions.Scala213),
     mdocOut := (ThisBuild / baseDirectory).value,
 
     mdocVariables := Map(


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

With the introduction of the `specs2_5` module which is only available for Scala 3, our build definition needs to be adapted for the release to work:
- removed the aggregated project, as it couldn't contain all projects. This was left after we started publishing the separate modules to ease migration, and I believe enough time has passed to remove it. 
- set `crossScalaVersions` specifically in each project, without defining it for `ThisBuild`.

### Does this change relate to existing issues or pull requests?

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->
Follow-up on #862.

### Does this change require an update to the documentation?

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->
No.

### How has this been tested?

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
Made sure the release process starts as expected, without the errors of trying to find a version of `specs2` 5 for scala 2.13.