### PR TITLE
Update scala-pool to 0.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,10 +110,7 @@ lazy val io = module(project, "io")
       BouncyCastlePkix,
       BouncyCastleProvider,
       ScalaLogging,
-      // FIXME: scala-pool is not avaiable for Scala 3, but we can use the Scala 2.13 version. This is currently only
-      //        being used to manage pools of SFTP clients for the same connection details. We should eventually
-      //        consider an alternative implementation.
-      ScalaPool.cross(CrossVersion.for3Use2_13),
+      ScalaPool,
       SshJ,
       TypesafeConfig,
       Specs2_4Core % Test

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     val JodaTime       = "2.14.0"
     val ScalaCheck     = "1.18.1"
     val ScalaLogging   = "3.9.5"
-    val ScalaPool      = "0.4.3"
+    val ScalaPool      = "0.5.0"
     val ScalaTest      = "3.2.19"
     val SimpleJmx      = "2.2"
     val Specs2_4       = "4.21.0"


### PR DESCRIPTION
Updates scala-pool to 0.5.0, which already has a Scala 3 version.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

No.

### How has this been tested?

I made sure I continued to be able to build the project successfully.