### PR TITLE
Add Changelog entry for 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Use the following schema when setting up the Changelog for a new release. Remove
 ### Security
 -->
 
+## [0.24.1] - 2025-07-09
+
+This release updates scala-pool (included in the apso-io module) to 0.5.0. This new version of scala-pool comes with
+native support for Scala 3.
+
+### Changed
+- Update sbt, scripted-plugin to 1.11.3 ([#869](https://github.com/adzerk/apso/pull/869)).
+- Update scala-pool to 0.5.0 ([#870](https://github.com/adzerk/apso/pull/870)).
+
+[0.24.1]: https://github.com/adzerk/apso/compare/v0.24.0...v0.24.1
+
 ## [0.24.0] - 2025-07-02
 This release adds a module for `specs2` v5 and renames the `testkit` module to keep consistency.
 
@@ -39,8 +50,8 @@ This release adds a module for `specs2` v5 and renames the `testkit` module to k
 
 [0.24.0]: https://github.com/adzerk/apso/compare/v0.23.0...v0.24.0
 
-
 ## [0.23.0] - 2025-06-09
+
 This release removes the dependency on `nscala-time` from apso-time, relying solely on `org.joda.time`'s API. This avoids introducing this dependency to any downstream users.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Apso's latest release is built against Scala 2.13 and Scala 3.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso" % "0.24.1"
 ```
 
 The project is divided in modules, you can instead install only a specific module.
@@ -19,7 +19,7 @@ The project is divided in modules, you can instead install only a specific modul
 The TestKit is available under the `apso-testkit` project. You can include it only for the `test` configuration:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-testkit" % "0.24.0" % "test"
+libraryDependencies += "com.kevel" %% "apso-testkit" % "0.24.1" % "test"
 ```
 
 Please take into account that the library is still in an experimental stage and the interfaces might change for subsequent releases.
@@ -69,7 +69,7 @@ Please take into account that the library is still in an experimental stage and 
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-core" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-core" % "0.24.1"
 ```
 
 ### Config
@@ -283,7 +283,7 @@ The `pekko-http` module provides additional [directives](https://pekko.apache.or
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-pekko-http" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-pekko-http" % "0.24.1"
 ```
 
 ### ClientIPDirectives
@@ -305,7 +305,7 @@ Apso provides a group of classes to ease the interaction with the Amazon Web Ser
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-aws" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-aws" % "0.24.1"
 ```
 
 ### ConfigCredentialsProvider
@@ -353,7 +353,7 @@ The `apso-caching` module provides utilities for caching, using `Caffeine` as th
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-caching" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-caching" % "0.24.1"
 ```
 
 The simplest use case is bootstrapping a cache implementation based on a configuration object:
@@ -425,7 +425,7 @@ y
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-collections" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-collections" % "0.24.1"
 ```
 
 ### Trie
@@ -626,7 +626,7 @@ creation of the underlying Cyphers.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-encryption" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-encryption" % "0.24.1"
 ```
 
 The following shows the creation of `Encryptor` and `Decryptor` objects,
@@ -651,7 +651,7 @@ decryptor.get.decryptToString(encryptor.get.encryptToSafeString(secretData).get)
 Apso provides utilities for various hashing functions. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-hashing" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-hashing" % "0.24.1"
 ```
 
 ```scala
@@ -671,7 +671,7 @@ Apso provides methods to deal with IO-related features in the `io` module.
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-io" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-io" % "0.24.1"
 ```
 
 ### FileDescriptor
@@ -714,7 +714,7 @@ ResourceUtil.getResourceAsString("reference.conf")
 Apso includes a bunch of utilities to work with JSON serialization and deserialization, specifically with the [circe](https://circe.github.io/circe/) library. To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-circe" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-circe" % "0.24.1"
 ```
 
 ### ExtraJsonProtocol
@@ -826,7 +826,7 @@ The `profiling` module of apso provides utilities to help with profiling the run
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-profiling" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-profiling" % "0.24.1"
 ```
 
 ### CpuSampler
@@ -844,7 +844,7 @@ The `apso-time` module provides utilities to work with `DateTime` and `LocalDate
 To use it in an existing SBT project, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-time" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-time" % "0.24.1"
 ```
 
 See the following sample usages:
@@ -956,11 +956,11 @@ Apso comes with TestKits with extra useful matchers for [specs2](https://etorreb
 To use the version for version 4 of `specs2`, add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-specs2_4" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-specs2_4" % "0.24.1"
 ```
 
 To use the version for version 5 of `specs2` (only available for Scala 3), add the following dependency to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.kevel" %% "apso-specs2_5" % "0.24.0"
+libraryDependencies += "com.kevel" %% "apso-specs2_5" % "0.24.1"
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,7 @@ lazy val docs = (project in file("apso-docs"))
     mdocOut := (ThisBuild / baseDirectory).value,
 
     mdocVariables := Map(
-      "VERSION" -> "0.24.0" // This version should be set to the currently released version.
+      "VERSION" -> "0.24.1" // This version should be set to the currently released version.
     ),
 
     publish / skip := true


### PR DESCRIPTION
Adds a Changelog entry for 0.24.1, ahead of its release.

### Does this change relate to existing issues or pull requests?

No.

### Does this change require an update to the documentation?

Yes. The current Apso version was updated accordingly.

### How has this been tested?

N/A