### PR TITLE
Add `StrictMatching` trait to `specs2_5` testkit

### DIFF
--- a/specs2_5/src/main/scala/com/kevel/apso/StrictMatching.scala
+++ b/specs2_5/src/main/scala/com/kevel/apso/StrictMatching.scala
@@ -1,0 +1,17 @@
+package com.kevel.apso
+
+import org.specs2.matcher.*
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.dsl.*
+
+/** Disables some `specs2` syntax, namely comparisons with `===` and `should` and expectation description methods that
+  * tend to be ambiguous with other libraries. One is encouraged to write consistent expectations with the `must`
+  * method.
+  */
+trait StrictMatching
+    extends NoTypedEqual
+    with NoShouldExpectations
+    with NoExpectationsDescription
+    with NoValueDescription
+    with NoBangExamples
+    with NoTitleDsl { self: SpecificationLike => }

--- a/specs2_5/src/main/scala/com/kevel/apso/StrictMatching.scala
+++ b/specs2_5/src/main/scala/com/kevel/apso/StrictMatching.scala
@@ -1,8 +1,8 @@
 package com.kevel.apso
 
-import org.specs2.matcher.*
+import org.specs2.matcher._
 import org.specs2.mutable.SpecificationLike
-import org.specs2.specification.dsl.*
+import org.specs2.specification.dsl._
 
 /** Disables some `specs2` syntax, namely comparisons with `===` and `should` and expectation description methods that
   * tend to be ambiguous with other libraries. One is encouraged to write consistent expectations with the `must`


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

In a quest for a more opinionated, simpler testing schema with `specs2`, we can use the new negation implicits introduced in `specs2_5`. The main purpose of this is to establish the use of `must` as the only syntax available.

### Does this change relate to existing issues or pull requests?

No.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

It can, if you think it is worth.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

I've included it in a downstream project and verified that the methods do not exist.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
