### PR TITLE
Add support for configuring private key content for SftpFileDescriptor

### DIFF
--- a/modules/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
@@ -345,6 +345,12 @@ object SftpFileDescriptor {
               username,
               Left(Identity(Right(new File(Properties.userHome + "/.ssh/" + keypairFile)), passphrase))
             )
+          case config.Credentials.Sftp.Entry.PublicKeyContent(username, privateKey, passphrase) =>
+            SftpFileDescriptor.Credentials(
+              hostname,
+              username,
+              Left(Identity(Left(privateKey), passphrase))
+            )
         }
       }
     }

--- a/modules/io/src/main/scala/com/kevel/apso/io/config/Credentials.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/config/Credentials.scala
@@ -23,6 +23,7 @@ object Credentials {
     object Entry {
       case class Basic(username: String, password: String) extends Entry
       case class PublicKey(username: String, keypairFile: String, passphrase: Option[String]) extends Entry
+      case class PublicKeyContent(username: String, privateKey: String, passphrase: Option[String]) extends Entry
     }
   }
 }

--- a/modules/io/src/test/scala/com/kevel/apso/io/SftpFileDescriptorSpec.scala
+++ b/modules/io/src/test/scala/com/kevel/apso/io/SftpFileDescriptorSpec.scala
@@ -1,6 +1,9 @@
 package com.kevel.apso.io
 
+import java.io.File
 import java.net.URI
+
+import scala.util.Properties
 
 import org.specs2.mutable.Specification
 
@@ -14,6 +17,32 @@ class SftpFileDescriptorSpec extends Specification {
         Credentials.Sftp(default = Some(Credentials.Sftp.Entry.Basic(username = "user123", password = "pass456")))
       )
       file.uri ==== new URI("sftp://user123@localhost/tmp/file")
+    }
+
+    "resolve a PublicKey config to an identity rooted at ~/.ssh/" in {
+      val file = SftpFileDescriptor(
+        "localhost/tmp/file",
+        Credentials.Sftp(default =
+          Some(Credentials.Sftp.Entry.PublicKey(username = "u", keypairFile = "id_rsa", passphrase = Some("phrase")))
+        )
+      )
+      file.identity ==== Some(
+        SftpFileDescriptor.Identity(Right(new File(Properties.userHome + "/.ssh/id_rsa")), Some("phrase"))
+      )
+    }
+
+    "resolve a PublicKeyContent config to an in-memory key identity without filesystem lookup" in {
+      val pem =
+        """-----BEGIN OPENSSH PRIVATE KEY-----
+          |b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB
+          |-----END OPENSSH PRIVATE KEY-----""".stripMargin
+      val file = SftpFileDescriptor(
+        "localhost/tmp/file",
+        Credentials.Sftp(default =
+          Some(Credentials.Sftp.Entry.PublicKeyContent(username = "u", privateKey = pem, passphrase = None))
+        )
+      )
+      file.identity ==== Some(SftpFileDescriptor.Identity(Left(pem), None))
     }
   }
 }


### PR DESCRIPTION
Add support for instantiating a SftpFileDescriptor using credentials indicating the private key content directly, instead of a file name.
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

### Does this change relate to existing issues or pull requests?
N/A
<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?
No.
<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?
N/A
<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
