### PR TITLE
Make SyncEvidence a public class

### DIFF
--- a/modules/caching/src/main/scala-2/com/kevel/apso/caching/SyncEvidence.scala
+++ b/modules/caching/src/main/scala-2/com/kevel/apso/caching/SyncEvidence.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
   * @tparam A
   *   the tagged type.
   */
-class SyncEvidence[A]
+class SyncEvidence[A] private[caching] ()
 
 object SyncEvidence extends LowPrioritySyncEvidence {
   implicit def ev1[A]: SyncEvidence[Future[A]] = new SyncEvidence[Future[A]]

--- a/modules/caching/src/main/scala-2/com/kevel/apso/caching/SyncEvidence.scala
+++ b/modules/caching/src/main/scala-2/com/kevel/apso/caching/SyncEvidence.scala
@@ -9,13 +9,13 @@ import scala.concurrent.Future
   * @tparam A
   *   the tagged type.
   */
-private[caching] trait SyncEvidence[A]
+class SyncEvidence[A]
 
-private[caching] object SyncEvidence extends LowPrioritySyncEvidence {
-  implicit def ev1[A]: SyncEvidence[Future[A]] = new SyncEvidence[Future[A]] {}
-  implicit def ev2[A]: SyncEvidence[Future[A]] = new SyncEvidence[Future[A]] {}
+object SyncEvidence extends LowPrioritySyncEvidence {
+  implicit def ev1[A]: SyncEvidence[Future[A]] = new SyncEvidence[Future[A]]
+  implicit def ev2[A]: SyncEvidence[Future[A]] = new SyncEvidence[Future[A]]
 }
 
-private[caching] trait LowPrioritySyncEvidence {
-  implicit def ev[A]: SyncEvidence[A] = new SyncEvidence[A] {}
+trait LowPrioritySyncEvidence {
+  implicit def ev[A]: SyncEvidence[A] = new SyncEvidence[A]
 }

--- a/modules/caching/src/main/scala-3/com/kevel/apso/caching/SyncEvidence.scala
+++ b/modules/caching/src/main/scala-3/com/kevel/apso/caching/SyncEvidence.scala
@@ -9,7 +9,7 @@ import scala.util.NotGiven
   * @tparam A
   *   the tagged type.
   */
-class SyncEvidence[A]
+class SyncEvidence[A] private[caching] ()
 
 object SyncEvidence {
   given [A](using NotGiven[A <:< Future[?]]): SyncEvidence[A] = SyncEvidence[A]

--- a/modules/caching/src/main/scala-3/com/kevel/apso/caching/SyncEvidence.scala
+++ b/modules/caching/src/main/scala-3/com/kevel/apso/caching/SyncEvidence.scala
@@ -3,13 +3,14 @@ package com.kevel.apso.caching
 import scala.concurrent.Future
 import scala.util.NotGiven
 
-/** An evidence that an `A` is not a `Future[_]`.
+/** An evidence that an `A` is not a `Future[?]`. This class and respective companion object are public since they are
+  * required by public methods, but they should not be used explicitly in user code.
   *
   * @tparam A
   *   the tagged type.
   */
-private[caching] trait SyncEvidence[A]
+class SyncEvidence[A]
 
-private[caching] object SyncEvidence {
-  implicit def ev[A](implicit notFuture: NotGiven[A <:< Future[_]]): SyncEvidence[A] = new SyncEvidence[A] {}
+object SyncEvidence {
+  given [A](using NotGiven[A <:< Future[?]]): SyncEvidence[A] = SyncEvidence[A]
 }


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

As of [Scala 3.8+](https://github.com/scala/scala3/pull/25367), and upcoming [Scala 2.13.19](https://github.com/scala/scala/pull/11215), resolving implicits from private companion objects is deprecated.

Opportunistically, I took the chance to make our `SyncEvidence` a simple class, as it has no behavior, and modernize the given in the Scala 3 version. The latter might raise binary binary compatibility issues as the signature is changed, but we don't promise stability in Apso. In any case, the `caching` module is typically used as a leaf in application code, so this should not matter too much.

### Does this change relate to existing issues or pull requests?

No, but the Scala 3.9 LTS version is around the corner and downstream projects started firing the warning:

```scala
[warn] xx |  }).cachedSync(config.Cache(None, None))
[warn]    |   ^
[warn]    |Usage of implicit method ev defined in object SyncEvidence, which is not accessible here. In Scala 3.10, this implicit will no longer be found.
```

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

No.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Existing spec.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
