### PR TITLE
Add move operation to `FileDescriptor` and refine base typing

### DIFF
--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -210,7 +210,7 @@ trait FileDescriptor {
 
   /** Move the file to a new location in the same file system. Cross file system moves are not supported.
     *
-    * This operation may be more efficient than a manual [[upload]] followed by a [[delete]].
+    * This operation may be more efficient than a manual `upload` followed by a `delete`.
     *
     * @param pathString
     *   the new location, specified using unix's mv syntax related to the current directory.

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -205,7 +205,9 @@ trait FileDescriptor {
     */
   protected final def mvLocation(pathString: String): Self = {
     val requestedDestination = parent().cd(pathString).asInstanceOf[Self]
-    if (requestedDestination.isDirectory) requestedDestination.child(name).asInstanceOf[Self] else requestedDestination
+    if (requestedDestination.exists && requestedDestination.isDirectory)
+      requestedDestination.child(name).asInstanceOf[Self]
+    else requestedDestination
   }
 
   /** Move the file to a new location in the same file system. Cross file system moves are not supported.

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -10,6 +10,8 @@ import scala.io.Source
   */
 trait FileDescriptor {
 
+  type Self <: FileDescriptor
+
   /** Returns the unique identifier of this file in its location.
     * @return
     *   the unique identifier of this file in its location.
@@ -96,7 +98,7 @@ trait FileDescriptor {
     * @return
     *   a iterator of file descriptors
     */
-  def list: Iterator[FileDescriptor]
+  def list: Iterator[Self]
 
   /** Lists all files down the file hierarchy tree that whose relative path match the given prefix
     * @param prefix
@@ -104,7 +106,7 @@ trait FileDescriptor {
     * @return
     *   a iterator of file descriptors
     */
-  def listAllFilesWithPrefix(prefix: String): Iterator[FileDescriptor]
+  def listAllFilesWithPrefix(prefix: String): Iterator[Self]
 
   /** Returns the file descriptor `n` node up in the filesystem path.
     * @param n
@@ -112,7 +114,7 @@ trait FileDescriptor {
     * @return
     *   the file descriptor `n` node up in the filesystem path.
     */
-  def parent(n: Int = 1): FileDescriptor
+  def parent(n: Int = 1): Self
 
   /** Adds a new child node to the filesystem path.
     * @param name
@@ -120,7 +122,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def child(name: String): FileDescriptor
+  def child(name: String): Self
 
   /** Adds a new child node to the filesystem path.
     * @param name
@@ -128,7 +130,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def /(name: String): FileDescriptor = child(name)
+  def /(name: String): Self = child(name)
 
   /** Adds multiple new child nodes to the filesystem path.
     * @param names
@@ -136,8 +138,8 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def children(names: String*): FileDescriptor =
-    names.foldLeft(this)((acc, c) => acc.child(c))
+  def children(names: String*): Self =
+    names.foldLeft(this.asInstanceOf[Self])((acc, c) => acc.child(c).asInstanceOf[Self])
 
   /** Changes the path of the file descriptor using unix's cd syntax related to the current directory.
     *
@@ -152,11 +154,11 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def cd(pathString: String): FileDescriptor = {
-    pathString.split("/").toList.foldLeft(this) {
+  def cd(pathString: String): Self = {
+    pathString.split("/").toList.foldLeft(this.asInstanceOf[Self]) {
       case (acc, "." | "") => acc
-      case (acc, "..")     => acc.parent()
-      case (acc, segment)  => acc.child(segment)
+      case (acc, "..")     => acc.parent().asInstanceOf[Self]
+      case (acc, segment)  => acc.child(segment).asInstanceOf[Self]
     }
   }
 
@@ -166,7 +168,7 @@ trait FileDescriptor {
     * @return
     *   a new file descriptor pointing to a sibling of the current file descriptor
     */
-  def sibling(name: String): FileDescriptor = sibling(_ => name)
+  def sibling(name: String): Self = sibling(_ => name)
 
   /** Returns a new file descriptor pointing to a sibling of the current file descriptor
     * @param f
@@ -174,7 +176,7 @@ trait FileDescriptor {
     * @return
     *   a new file descriptor pointing to a sibling of the current file descriptor
     */
-  def sibling(f: String => String): FileDescriptor = parent().child(f(name))
+  def sibling(f: String => String): Self = parent().child(f(name)).asInstanceOf[Self]
 
   /** Returns true if the file pointed by the file descriptor exists
     * @return
@@ -193,6 +195,29 @@ trait FileDescriptor {
     *   true if the creation of successful, false otherwise.
     */
   def mkdirs(): Boolean
+
+  /** A new file descriptor pointing to the new location of the file after a candidate move operation.
+    *
+    * @param pathString
+    *   the new location, specified using unix's mv syntax related to the current directory.
+    * @return
+    *   the candidate file descriptor.
+    */
+  protected final def mvLocation(pathString: String): Self = {
+    val requestedDestination = parent().cd(pathString).asInstanceOf[Self]
+    if (requestedDestination.isDirectory) requestedDestination.child(name).asInstanceOf[Self] else requestedDestination
+  }
+
+  /** Move the file to a new location in the same file system. Cross file system moves are not supported.
+    *
+    * This operation may be more efficient than a manual [[upload]] followed by a [[delete]].
+    *
+    * @param pathString
+    *   the new location, specified using unix's mv syntax related to the current directory.
+    * @return
+    *   the new file descriptor with the updated path if the move was successful, None otherwise.
+    */
+  def move(pathString: String): Option[Self]
 }
 
 object FileDescriptor {

--- a/modules/io/src/main/scala/com/kevel/apso/io/GCSFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/GCSFileDescriptor.scala
@@ -3,6 +3,8 @@ package com.kevel.apso.io
 import java.io.InputStream
 import java.net.URI
 
+import scala.util.Using
+
 import com.google.cloud.storage.{Blob, Storage, StorageOptions}
 
 import com.kevel.apso.gcp.GCSBucket
@@ -104,6 +106,15 @@ case class GCSFileDescriptor(
     val result = isDirectory || bucket.createDirectory(builtPath)
     isDirectoryLocal = result
     result
+  }
+
+  def move(pathString: String): Option[GCSFileDescriptor] = {
+    val destination = mvLocation(pathString)
+    if (destination.elements == elements) Some(this)
+    else {
+      val copied = Using.resource(stream())(input => destination.upload(input, Some(size)))
+      if (copied && delete()) Some(destination.copy(summary = None)) else None
+    }
   }
 
   override def toString: String = uri.toString

--- a/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
@@ -199,7 +199,9 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
         Files.move(normalizedPath, destination.normalizedPath, StandardCopyOption.ATOMIC_MOVE)
         Some(destination)
       } catch {
-        case NonFatal(_) => None
+        case NonFatal(_) =>
+          logger.warn(s"File move failed from $path to ${destination.path}")
+          None
       }
   }
 

--- a/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
@@ -5,6 +5,7 @@ import java.net.URI
 import java.nio.file.{Files, Path, Paths, StandardCopyOption}
 
 import scala.io.Source
+import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 import com.typesafe.scalalogging.LazyLogging
@@ -12,6 +13,8 @@ import com.typesafe.scalalogging.LazyLogging
 import com.kevel.apso.Implicits.ApsoCloseable
 
 case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with LazyLogging {
+
+  type Self = LocalFileDescriptor
 
   @transient private[this] var _normalizedPath: Path = _
 
@@ -186,6 +189,18 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   def rename(to: LocalFileDescriptor): Option[LocalFileDescriptor] = {
     to.parent().mkdirs()
     if (file.renameTo(to.file)) Some(to) else None
+  }
+
+  def move(pathString: String): Option[LocalFileDescriptor] = {
+    val destination = mvLocation(pathString)
+    if (destination == this) Some(this)
+    else
+      try {
+        Files.move(normalizedPath, destination.normalizedPath, StandardCopyOption.ATOMIC_MOVE)
+        Some(destination)
+      } catch {
+        case NonFatal(_) => None
+      }
   }
 
   /** Writes the given string `str` to the file pointed by the file descriptor

--- a/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
@@ -193,7 +193,7 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
 
   def move(pathString: String): Option[LocalFileDescriptor] = {
     val destination = mvLocation(pathString)
-    if (destination == this) Some(this)
+    if (destination.path == path) Some(this)
     else
       try {
         Files.move(normalizedPath, destination.normalizedPath, StandardCopyOption.ATOMIC_MOVE)

--- a/modules/io/src/main/scala/com/kevel/apso/io/RemoteFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/RemoteFileDescriptor.scala
@@ -1,8 +1,6 @@
 package com.kevel.apso.io
 
 trait RemoteFileDescriptor { this: FileDescriptor =>
-  type Self <: RemoteFileDescriptor
-
   protected def elements: List[String]
   protected def root: String
 

--- a/modules/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 import java.net.URI
 
 import scala.collection.concurrent.TrieMap
+import scala.util.Using
 
 import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
 import software.amazon.awssdk.services.s3.model.S3Object
@@ -125,6 +126,15 @@ case class S3FileDescriptor(
     val result = isDirectory || bucket.createDirectory(builtPath)
     isDirectoryLocal = result
     result
+  }
+
+  def move(pathString: String): Option[S3FileDescriptor] = {
+    val destination = mvLocation(pathString)
+    if (destination.elements == elements) Some(this)
+    else {
+      val copied = Using.resource(stream())(input => destination.upload(input, Some(size)))
+      if (copied && delete()) Some(destination.copy(summary = None)) else None
+    }
   }
 
   override def toString: String =

--- a/modules/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/SftpFileDescriptor.scala
@@ -141,6 +141,13 @@ case class SftpFileDescriptor(
   def mkdirs(): Boolean =
     Try(sftp(_.mkdirs(path))).isSuccess
 
+  def move(pathString: String): Option[SftpFileDescriptor] = {
+    val destination = mvLocation(pathString)
+    if (destination.path == path) Some(this)
+    else if (destination.parent().mkdirs() && Try(sftp(_.rename(path, destination.path))).isSuccess) Some(destination)
+    else None
+  }
+
   def download(localTarget: LocalFileDescriptor, safeDownloading: Boolean): Boolean = {
     require(!localTarget.isDirectory, s"Local file descriptor can't point to a directory: ${localTarget.path}")
     require(!isDirectory, s"Remote file descriptor can't point to a directory: ${this.path}")

--- a/modules/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
+++ b/modules/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
@@ -111,6 +111,39 @@ class LocalFileDescriptorSpec extends Specification {
         LocalFileDescriptor("/tmp/one/two/four/five")
     }
 
+    "move a file to its parent directory" in {
+      val source = LocalFileDescriptor("/tmp") / randomFolder / randomString
+      source.write("hello world")
+
+      source.move(s"../$randomString") must beSome.which { destination =>
+        destination.readString must beEqualTo("hello world")
+        source.exists must beFalse
+      }
+    }
+
+    "move a file to the same directory" in {
+      val source = LocalFileDescriptor("/tmp") / randomFolder / randomString
+      source.write("hello world")
+
+      source.move(randomString) must beSome.which { destination =>
+        destination.readString must beEqualTo("hello world")
+        source.exists must beFalse
+      }
+    }
+
+    "move a directory" in {
+      val source = LocalFileDescriptor("/tmp") / randomFolder / randomString
+      (source / "one").write("hello world")
+      (source / "two").write("hello world 2")
+
+      source.move(randomString) must beSome.which { destination =>
+        destination.list.toSet must beEqualTo(Set(destination / "one", destination / "two"))
+        (destination / "one").readString must beEqualTo("hello world")
+        (destination / "two").readString must beEqualTo("hello world 2")
+        source.exists must beFalse
+      }
+    }
+
     "create intermediary folders when required" in {
       val fd = LocalFileDescriptor("/tmp") / randomFolder / randomString
       val f = fd.children("one", "two")

--- a/modules/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
+++ b/modules/io/src/test/scala/com/kevel/apso/io/LocalFileDescriptorSpec.scala
@@ -115,7 +115,7 @@ class LocalFileDescriptorSpec extends Specification {
       val source = LocalFileDescriptor("/tmp") / randomFolder / randomString
       source.write("hello world")
 
-      source.move(s"../$randomString") must beSome.which { destination =>
+      source.move(s"../$randomString") must beSome[LocalFileDescriptor].which { destination =>
         destination.readString must beEqualTo("hello world")
         source.exists must beFalse
       }
@@ -125,7 +125,7 @@ class LocalFileDescriptorSpec extends Specification {
       val source = LocalFileDescriptor("/tmp") / randomFolder / randomString
       source.write("hello world")
 
-      source.move(randomString) must beSome.which { destination =>
+      source.move(randomString) must beSome[LocalFileDescriptor].which { destination =>
         destination.readString must beEqualTo("hello world")
         source.exists must beFalse
       }
@@ -136,7 +136,7 @@ class LocalFileDescriptorSpec extends Specification {
       (source / "one").write("hello world")
       (source / "two").write("hello world 2")
 
-      source.move(randomString) must beSome.which { destination =>
+      source.move(randomString) must beSome[LocalFileDescriptor].which { destination =>
         destination.list.toSet must beEqualTo(Set(destination / "one", destination / "two"))
         (destination / "one").readString must beEqualTo("hello world")
         (destination / "two").readString must beEqualTo("hello world 2")


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

Adds a new move operation to `FileDescriptor` that behaves similarly to UNIX's `mv` utility.

- Moving directories will unsupported file systems (e.g. GCS or S3) will throw, as `upload` already does.
- Failing the operation, due to some I/O error, returns None.
- A successful move returns the new file descriptor.

Most notably, I am interested in using the `move` method for sftp.

Opportunistically, Self was moved up, requiring implementations to return their own type (which they already did), and using it for the `mvLocation` method up in the hierarchy.

### Does this change relate to existing issues or pull requests?

No.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Tested the local version via new unit tests.
Tested the sftp version against a local sftp server.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
