### PR TITLE
Remove unnecessary `FileDescriptor` overrides

### DIFF
--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -86,7 +86,7 @@ trait FileDescriptor {
     * @return
     *   an iterator with the lines of this file.
     */
-  final def lines(): Iterator[String] = Source.fromInputStream(stream()).getLines()
+  def lines(): Iterator[String] = Source.fromInputStream(stream()).getLines()
 
   /** Returns true if the fd points to a directory
     * @return
@@ -138,7 +138,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  final def children(names: String*): Self =
+  def children(names: String*): Self =
     names.foldLeft(this.asInstanceOf[Self])((acc, c) => acc.child(c).asInstanceOf[Self])
 
   /** Changes the path of the file descriptor using unix's cd syntax related to the current directory.
@@ -176,7 +176,7 @@ trait FileDescriptor {
     * @return
     *   a new file descriptor pointing to a sibling of the current file descriptor
     */
-  final def sibling(f: String => String): Self = parent().child(f(name)).asInstanceOf[Self]
+  def sibling(f: String => String): Self = parent().child(f(name)).asInstanceOf[Self]
 
   /** Returns true if the file pointed by the file descriptor exists
     * @return

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -155,7 +155,7 @@ trait FileDescriptor {
     *   the new file descriptor with the updated path
     */
   final def cd(pathString: String): Self = {
-    pathString.split("/").toList.foldLeft(this.asInstanceOf[Self]) {
+    pathString.split("/").map(_.trim).toList.foldLeft(this.asInstanceOf[Self]) {
       case (acc, "." | "") => acc
       case (acc, "..")     => acc.parent().asInstanceOf[Self]
       case (acc, segment)  => acc.child(segment).asInstanceOf[Self]

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -86,7 +86,7 @@ trait FileDescriptor {
     * @return
     *   an iterator with the lines of this file.
     */
-  def lines(): Iterator[String] = Source.fromInputStream(stream()).getLines()
+  final def lines(): Iterator[String] = Source.fromInputStream(stream()).getLines()
 
   /** Returns true if the fd points to a directory
     * @return
@@ -130,7 +130,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def /(name: String): Self = child(name)
+  final def /(name: String): Self = child(name)
 
   /** Adds multiple new child nodes to the filesystem path.
     * @param names
@@ -138,7 +138,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def children(names: String*): Self =
+  final def children(names: String*): Self =
     names.foldLeft(this.asInstanceOf[Self])((acc, c) => acc.child(c).asInstanceOf[Self])
 
   /** Changes the path of the file descriptor using unix's cd syntax related to the current directory.
@@ -154,7 +154,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  def cd(pathString: String): Self = {
+  final def cd(pathString: String): Self = {
     pathString.split("/").toList.foldLeft(this.asInstanceOf[Self]) {
       case (acc, "." | "") => acc
       case (acc, "..")     => acc.parent().asInstanceOf[Self]
@@ -168,7 +168,7 @@ trait FileDescriptor {
     * @return
     *   a new file descriptor pointing to a sibling of the current file descriptor
     */
-  def sibling(name: String): Self = sibling(_ => name)
+  final def sibling(name: String): Self = sibling(_ => name)
 
   /** Returns a new file descriptor pointing to a sibling of the current file descriptor
     * @param f
@@ -176,7 +176,7 @@ trait FileDescriptor {
     * @return
     *   a new file descriptor pointing to a sibling of the current file descriptor
     */
-  def sibling(f: String => String): Self = parent().child(f(name)).asInstanceOf[Self]
+  final def sibling(f: String => String): Self = parent().child(f(name)).asInstanceOf[Self]
 
   /** Returns true if the file pointed by the file descriptor exists
     * @return

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -155,7 +155,7 @@ trait FileDescriptor {
     *   the new file descriptor with the updated path
     */
   def cd(pathString: String): Self = {
-    pathString.split("/").map(_.trim).toList.foldLeft(this.asInstanceOf[Self]) {
+    pathString.split("/").iterator.map(_.trim).foldLeft(this.asInstanceOf[Self]) {
       case (acc, "." | "") => acc
       case (acc, "..")     => acc.parent().asInstanceOf[Self]
       case (acc, segment)  => acc.child(segment).asInstanceOf[Self]

--- a/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/FileDescriptor.scala
@@ -154,7 +154,7 @@ trait FileDescriptor {
     * @return
     *   the new file descriptor with the updated path
     */
-  final def cd(pathString: String): Self = {
+  def cd(pathString: String): Self = {
     pathString.split("/").map(_.trim).toList.foldLeft(this.asInstanceOf[Self]) {
       case (acc, "." | "") => acc
       case (acc, "..")     => acc.parent().asInstanceOf[Self]

--- a/modules/io/src/main/scala/com/kevel/apso/io/GCSFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/GCSFileDescriptor.scala
@@ -61,15 +61,6 @@ case class GCSFileDescriptor(
 
   def stream(offset: Long = 0L): InputStream = bucket.stream(builtPath, offset)
 
-  override def cd(pathString: String): GCSFileDescriptor = {
-    val newPath = pathString.split("/").map(_.trim).toList.foldLeft(elements) {
-      case (acc, "." | "") => acc
-      case (acc, "..")     => acc.dropRight(1)
-      case (acc, segment)  => acc :+ segment
-    }
-    this.copy(elements = newPath)
-  }
-
   override def list: Iterator[GCSFileDescriptor] = {
     val prefix = elements.mkString("/")
     bucket
@@ -84,9 +75,6 @@ case class GCSFileDescriptor(
       this.copy(elements = blob.getName.split("/").toList, summary = Some(blob))
     }
   }
-
-  override def sibling(f: String => String): GCSFileDescriptor =
-    GCSFileDescriptor(bucket, elements.dropRight(1) :+ f(name))
 
   private lazy val isDirectoryRemote: Boolean =
     elements.isEmpty || bucket.isDirectory(builtPath)

--- a/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/LocalFileDescriptor.scala
@@ -45,27 +45,9 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
     LocalFileDescriptor(parentPath.toString)
   }
 
-  override def /(name: String): LocalFileDescriptor = child(name)
-
   def child(name: String): LocalFileDescriptor = {
     val childPath = normalizedPath.resolve(name)
     LocalFileDescriptor(childPath.toString)
-  }
-
-  override def children(names: String*): LocalFileDescriptor = {
-    val childPath = names.foldLeft(normalizedPath) { (acc, child) =>
-      acc.resolve(child)
-    }
-    LocalFileDescriptor(childPath.toString)
-  }
-
-  override def cd(pathString: String): LocalFileDescriptor = {
-    val newPath = pathString.split("/").map(_.trim).toList.foldLeft(normalizedPath) {
-      case (acc, "." | "") => acc
-      case (acc, "..")     => acc.getParent
-      case (acc, segment)  => acc.resolve(segment)
-    }
-    LocalFileDescriptor(newPath.toString)
   }
 
   def download(localTarget: LocalFileDescriptor, safeDownloading: Boolean): Boolean = {
@@ -156,10 +138,6 @@ case class LocalFileDescriptor(initialPath: String) extends FileDescriptor with 
   }
 
   def exists: Boolean = file.exists()
-
-  override def sibling(f: String => String): LocalFileDescriptor = {
-    LocalFileDescriptor(normalizedPath.resolveSibling(f(name)).toString)
-  }
 
   def delete(): Boolean = file.delete()
 

--- a/modules/io/src/main/scala/com/kevel/apso/io/RemoteFileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/RemoteFileDescriptor.scala
@@ -25,12 +25,9 @@ trait RemoteFileDescriptor { this: FileDescriptor =>
 
   protected def duplicate(elements: List[String]): Self
 
-  def parent(n: Int = 1): Self =
+  final def parent(n: Int = 1): Self =
     this.duplicate(elements = elements.dropRight(n))
 
-  def child(name: String): Self =
+  final def child(name: String): Self =
     this.duplicate(elements = elements ++ sanitize(name).toList)
-
-  override def children(names: String*): Self =
-    this.duplicate(elements = elements ++ names.flatMap(sanitize))
 }

--- a/modules/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
+++ b/modules/io/src/main/scala/com/kevel/apso/io/S3FileDescriptor.scala
@@ -77,15 +77,6 @@ case class S3FileDescriptor(
 
   def stream(offset: Long = 0L) = bucket.stream(builtPath, offset)
 
-  override def cd(pathString: String): S3FileDescriptor = {
-    val newPath = pathString.split("/").map(_.trim).toList.foldLeft(elements) {
-      case (acc, "." | "") => acc
-      case (acc, "..")     => acc.dropRight(1)
-      case (acc, segment)  => acc :+ segment
-    }
-    this.copy(elements = newPath)
-  }
-
   override def list: Iterator[S3FileDescriptor] = {
     val prefix = elements.mkString("/")
     bucket
@@ -103,10 +94,6 @@ case class S3FileDescriptor(
 
   private[this] def listS3WithPrefix(prefix: String, includeDirectories: Boolean): Iterator[S3Object] = {
     bucket.getObjectsWithMatchingPrefix(buildPath(elements :+ prefix), includeDirectories)
-  }
-
-  override def sibling(f: String => String): S3FileDescriptor = {
-    S3FileDescriptor(bucket, elements.dropRight(1) :+ f(name))
   }
 
   private lazy val isDirectoryRemote = {


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

These operations are safe to perform at the base. There is no need to repeat them in implementations – they were sometimes slightly more efficient (e.g. not allocating intermediate wrappers while descending through child directories) but I don't think that is significant enough to maintain more code.

### Does this change relate to existing issues or pull requests?

Opportunistic change after https://github.com/adzerk/apso/pull/1128.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

No.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

I am relying on the soundness of the `parent` and `child` implementations.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
