### PR TITLE
Add invalidation methods to cached functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ y
 // res31: AtomicInteger = 3
 ```
 
+Cached function types provide `invalidate` and/or `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
+
 ## Collections
 
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ y
 // res31: AtomicInteger = 3
 ```
 
-Cached function types provide `invalidate` and/or `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
+Cached function types provide `invalidate` and `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
 
 ## Collections
 

--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,7 @@ lazy val docs = (project in file("apso-docs"))
   .dependsOn(aws, caching, circe, collections, core, encryption, gcp, hashing, io, pekko, pekkoHttp, profiling, time)
   .settings(
     crossScalaVersions := List(Versions.Scala213),
-    mdocOut            := baseDirectory.value,
+    mdocOut            := (LocalRootProject / baseDirectory).value,
 
     mdocVariables := Map(
       "VERSION" ->

--- a/docs/README.md
+++ b/docs/README.md
@@ -389,7 +389,7 @@ Await.result(cachedFutFn(3), Duration.Inf)
 y
 ```
 
-Cached function types provide `invalidate` and/or `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
+Cached function types provide `invalidate` and `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
 
 ## Collections
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -389,6 +389,8 @@ Await.result(cachedFutFn(3), Duration.Inf)
 y
 ```
 
+Cached function types provide `invalidate` and/or `invalidateAll` methods for use cases where the cache needs to be invalidated before the expiration time is reached.
+
 ## Collections
 
 The `apso-collections` module provides some helpful collections. To use it in an existing SBT project, add the following dependency to your `build.sbt`:

--- a/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
+++ b/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
@@ -10,26 +10,28 @@ import MemoizeFn._
   * Provides a memoization mechanism for synchronous functions with 0 arguments using Caffeine.
   *
   * Provides a corresponding `apply()` method that follows the signature of the provided `fn` function, but is
-  * memoized using Caffeine.
+  * memoized using Caffeine. The underlying cached result can be evicted via `invalidate`.
   */
 sealed trait SyncMemoizeFn0[V] extends (() => V) {
   protected def cacheConfig: config.Cache
   protected def fn: Unit => V
   private lazy val cache: LoadingCache[Unit, V] = cacheConfig.build.build(fn)
   override def apply(): V = cache.get(())
+  def invalidate(): Unit = cache.invalidate(())
 }
 
 /**
   * Provides a memoization mechanism for asynchronous functions with 0 arguments using Caffeine.
   *
   * Provides a corresponding `apply()` method that follows the signature of the provided `fn` function, but is
-  * memoized using Caffeine.
+  * memoized using Caffeine. The underlying cached result can be evicted via `invalidate`.
   */
 sealed trait AsyncMemoizeFn0[V] extends (() => Future[V]) {
   protected def cacheConfig: config.Cache
   protected def fn: Unit => Future[V]
   private lazy val cache: AsyncLoadingCache[Unit, V] = cacheConfig.build.buildAsyncFuture(fn)
   override def apply(): Future[V] = cache.get(())
+  def invalidate(): Unit = cache.synchronous().invalidate(())
 }
 
 [#
@@ -37,13 +39,14 @@ sealed trait AsyncMemoizeFn0[V] extends (() => Future[V]) {
   * Provides a memoization mechanism for synchronous functions with 1 arguments using Caffeine.
   *
   * Provides a corresponding `apply()` method that follows the signature of the provided `fn` function, but is
-  * memoized using Caffeine.
+  * memoized using Caffeine. Underlying cached entries can be evicted via `invalidate`.
   */
 sealed trait SyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], V] {
   def cacheConfig: config.Cache
   def fn: ([#I0#]) => V
   private lazy val cache: LoadingCache[([#I0#]), V] = cacheConfig.build.build(fn.tupled)
   override def apply([#i0: I0#]): V = cache.get(([#i0#]))
+  def invalidate([#i0: I0#]): Unit = cache.invalidate(([#i0#]))
 }#
 ]
 
@@ -52,13 +55,14 @@ sealed trait SyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], V] {
   * Provides a memoization mechanism for synchronous functions with 1 arguments using Caffeine.
   *
   * Provides a corresponding `apply()` method that follows the signature of the provided `fn` function, but is
-  * memoized using Caffeine.
+  * memoized using Caffeine. Underlying cached entries can be evicted via `invalidate`.
   */
 sealed trait AsyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], Future[V]] {
   def cacheConfig: config.Cache
   def fn: ([#I0#]) => Future[V]
   private lazy val cache: AsyncLoadingCache[([#I0#]), V] = cacheConfig.build.buildAsyncFuture(fn.tupled)
   override def apply([#i0: I0#]): Future[V] = cache.get(([#i0#]))
+  def invalidate([#i0: I0#]): Unit = cache.synchronous().invalidate(([#i0#]))
 }#
 ]
 

--- a/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
+++ b/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
@@ -18,6 +18,7 @@ sealed trait SyncMemoizeFn0[V] extends (() => V) {
   private lazy val cache: LoadingCache[Unit, V] = cacheConfig.build.build(fn)
   override def apply(): V = cache.get(())
   def invalidate(): Unit = cache.invalidate(())
+  def invalidateAll(): Unit = cache.invalidateAll()
 }
 
 /**
@@ -32,6 +33,7 @@ sealed trait AsyncMemoizeFn0[V] extends (() => Future[V]) {
   private lazy val cache: AsyncLoadingCache[Unit, V] = cacheConfig.build.buildAsyncFuture(fn)
   override def apply(): Future[V] = cache.get(())
   def invalidate(): Unit = cache.synchronous().invalidate(())
+  def invalidateAll(): Unit = cache.synchronous().invalidateAll()
 }
 
 [#

--- a/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
+++ b/modules/caching/src/main/boilerplate/com/kevel/apso/caching/MemoizeFn.scala.template
@@ -47,6 +47,7 @@ sealed trait SyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], V] {
   private lazy val cache: LoadingCache[([#I0#]), V] = cacheConfig.build.build(fn.tupled)
   override def apply([#i0: I0#]): V = cache.get(([#i0#]))
   def invalidate([#i0: I0#]): Unit = cache.invalidate(([#i0#]))
+  def invalidateAll(): Unit = cache.invalidateAll()
 }#
 ]
 
@@ -63,6 +64,7 @@ sealed trait AsyncMemoizeFn1[[#I0#], V] extends Function1[[#I0#], Future[V]] {
   private lazy val cache: AsyncLoadingCache[([#I0#]), V] = cacheConfig.build.buildAsyncFuture(fn.tupled)
   override def apply([#i0: I0#]): Future[V] = cache.get(([#i0#]))
   def invalidate([#i0: I0#]): Unit = cache.synchronous().invalidate(([#i0#]))
+  def invalidateAll(): Unit = cache.synchronous().invalidateAll()
 }#
 ]
 

--- a/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
+++ b/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
@@ -62,12 +62,17 @@ class CachedFunctionsExtrasSpec(implicit ee: ExecutionEnv) extends Specification
 
       "evicting a key after explicit invalidation" in {
         val counter = new AtomicInteger(0)
-        val f = () => counter.getAndIncrement()
+        val f: Int => Int = x => x + counter.getAndIncrement()
         val cachedF = f.cachedSync(config.Cache(Some(1.day), None))
-        cachedF() must beEqualTo(0)
-        cachedF() must beEqualTo(0)
-        cachedF.invalidate()
-        cachedF() must beEqualTo(1)
+        cachedF(1) must beEqualTo(1)
+        cachedF(1) must beEqualTo(1)
+        cachedF(2) must beEqualTo(3)
+        cachedF.invalidate(1)
+        cachedF(1) must beEqualTo(3)
+        cachedF(2) must beEqualTo(3)
+        cachedF.invalidate(2)
+        cachedF(1) must beEqualTo(3)
+        cachedF(2) must beEqualTo(5)
       }
 
       "evicting the entire cache after explicit invalidation" in {

--- a/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
+++ b/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
@@ -60,6 +60,28 @@ class CachedFunctionsExtrasSpec(implicit ee: ExecutionEnv) extends Specification
         quickly(cachedF() must beEqualTo(2))
       }
 
+      "evicting a key after explicit invalidation" in {
+        val counter = new AtomicInteger(0)
+        val f = () => counter.getAndIncrement()
+        val cachedF = f.cachedSync(config.Cache(Some(1.day), None))
+        cachedF() must beEqualTo(0)
+        cachedF() must beEqualTo(0)
+        cachedF.invalidate()
+        cachedF() must beEqualTo(1)
+      }
+
+      "evicting the entire cache after explicit invalidation" in {
+        val counter = new AtomicInteger(0)
+        val f: Int => Int = x => x + counter.getAndIncrement()
+        val cachedF = f.cachedSync(config.Cache(None, None))
+        cachedF(1) must beEqualTo(1)
+        cachedF(2) must beEqualTo(3)
+        cachedF(2) must beEqualTo(3)
+        cachedF.invalidateAll()
+        cachedF(1) must beEqualTo(3)
+        cachedF(2) must beEqualTo(5)
+      }
+
       "that resorts to the `hashCode` method of the key" in {
         val hashCodeCallCounter = new AtomicInteger(0)
         val toStringCallCounter = new AtomicInteger(0)

--- a/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
+++ b/modules/caching/src/test/scala/com/kevel/apso/caching/CachedFunctionsExtrasSpec.scala
@@ -3,8 +3,8 @@ package com.kevel.apso.caching
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.logging.{Level, Logger}
 
-import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Future, Promise}
 
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.AsResult
@@ -27,11 +27,26 @@ class CachedFunctionsExtrasSpec(implicit ee: ExecutionEnv) extends Specification
             "dummy"
         // format: on
 
-        f.cachedSync(config.Cache(None, None))() must beEqualTo(1)
-        f2.cachedSync(config.Cache(None, None))(0) must beEqualTo(2)
-        f3.cachedSync(config.Cache(None, None))(0, 1) must beEqualTo("hello")
-        f4.cachedSync(config.Cache(None, None))(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-          21, 22) must beEqualTo("dummy")
+        val cachedF = f.cachedSync(config.Cache(None, None))
+        val cachedF2 = f2.cachedSync(config.Cache(None, None))
+        val cachedF3 = f3.cachedSync(config.Cache(None, None))
+        val cachedF4 = f4.cachedSync(config.Cache(None, None))
+
+        cachedF() must beEqualTo(1)
+        cachedF2(0) must beEqualTo(2)
+        cachedF3(0, 1) must beEqualTo("hello")
+        cachedF4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22) must beEqualTo("dummy")
+
+        cachedF.invalidate() must beEqualTo(())
+        cachedF2.invalidate(0) must beEqualTo(())
+        cachedF3.invalidate(0, 1) must beEqualTo(())
+        cachedF4.invalidate(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22) must
+          beEqualTo(())
+
+        cachedF.invalidateAll() must beEqualTo(())
+        cachedF2.invalidateAll() must beEqualTo(())
+        cachedF3.invalidateAll() must beEqualTo(())
+        cachedF4.invalidateAll() must beEqualTo(())
       }
 
       "respecting key-value semantics" in {
@@ -145,11 +160,27 @@ class CachedFunctionsExtrasSpec(implicit ee: ExecutionEnv) extends Specification
             Future.successful("dummy")
         // format: on
 
-        f.cachedAsync(config.Cache(None, None))() must beEqualTo(1).await
-        f2.cachedAsync(config.Cache(None, None))(0) must beEqualTo(2).await
-        f3.cachedAsync(config.Cache(None, None))(0, 1) must beEqualTo("hello").await
-        f4.cachedAsync(config.Cache(None, None))(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-          21, 22) must beEqualTo("dummy").await
+        val cachedF = f.cachedAsync(config.Cache(None, None))
+        val cachedF2 = f2.cachedAsync(config.Cache(None, None))
+        val cachedF3 = f3.cachedAsync(config.Cache(None, None))
+        val cachedF4 = f4.cachedAsync(config.Cache(None, None))
+
+        cachedF() must beEqualTo(1).await
+        cachedF2(0) must beEqualTo(2).await
+        cachedF3(0, 1) must beEqualTo("hello").await
+        cachedF4(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22) must
+          beEqualTo("dummy").await
+
+        cachedF.invalidate() must beEqualTo(())
+        cachedF2.invalidate(0) must beEqualTo(())
+        cachedF3.invalidate(0, 1) must beEqualTo(())
+        cachedF4.invalidate(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22) must
+          beEqualTo(())
+
+        cachedF.invalidateAll() must beEqualTo(())
+        cachedF2.invalidateAll() must beEqualTo(())
+        cachedF3.invalidateAll() must beEqualTo(())
+        cachedF4.invalidateAll() must beEqualTo(())
       }
 
       "quickly evicting failing futures" in {
@@ -168,6 +199,56 @@ class CachedFunctionsExtrasSpec(implicit ee: ExecutionEnv) extends Specification
         quickly(cachedF() must not(throwA[RuntimeException]).await)
         cachedF() must beEqualTo(1).await
         cachedF() must beEqualTo(1).await
+      }
+
+      "evicting an in-flight computation without cancelling it" in {
+        val counter = new AtomicInteger(0)
+        val firstComputation = Promise[Int]()
+        val secondComputation = Promise[Int]()
+        val f: Int => Future[Int] = _ =>
+          counter.getAndIncrement() match {
+            case 0 => firstComputation.future
+            case 1 => secondComputation.future
+            case n => Future.failed(new IllegalStateException(s"Unexpected computation $n"))
+          }
+        val cachedF = f.cachedAsync(config.Cache(None, None))
+
+        val firstCall = cachedF(1)
+        val concurrentCall = cachedF(1)
+        counter.get() must beEqualTo(1)
+
+        cachedF.invalidate(1)
+        val replacementCall = cachedF(1)
+        counter.get() must beEqualTo(2)
+
+        firstComputation.success(1)
+        firstCall must beEqualTo(1).await
+        concurrentCall must beEqualTo(1).await
+        replacementCall.isCompleted must beFalse
+        cachedF(1).isCompleted must beFalse
+        counter.get() must beEqualTo(2)
+
+        secondComputation.success(2)
+        replacementCall must beEqualTo(2).await
+        cachedF(1) must beEqualTo(2).await
+        counter.get() must beEqualTo(2)
+      }
+
+      "evicting the entire cache after explicit invalidation" in {
+        val counter = new AtomicInteger(0)
+        val f: Int => Future[Int] = x => Future.successful(counter.getAndIncrement())
+        val cachedF = f.cachedAsync(config.Cache(None, None))
+
+        cachedF(1) must beEqualTo(0).await
+        cachedF(2) must beEqualTo(1).await
+
+        cachedF(1) must beEqualTo(0).await
+        cachedF(2) must beEqualTo(1).await
+
+        cachedF.invalidateAll()
+
+        cachedF(1) must beEqualTo(2).await
+        cachedF(2) must beEqualTo(3).await
       }
     }
   }


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

Some users might want to invalidate entries manually, instead of waiting for the cached time window to end. In the case of async functions, the method is synchronous, but the underlying implementation seems to just remove the `Future` entry from the Caffeine map.

The current build compiles the README under `apso-docs`, which is incorrect. (Might have broken as part of the sbt2 upgrade or lift to the `modules` subdir.) I'm sneaking a fix for that here so that I can update the README with this change.

### Does this change relate to existing issues or pull requests?

No.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

Yes.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Two new examples and looked at the generated sources.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
