### PR TITLE
Work around duplicate sbt-boilerplate generation under sbt2 and bump version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,9 +78,10 @@ scmInfo  := Some(
   )
 )
 
-releaseCrossBuild    := true
-releaseTagComment    := s"Release ${version.value}"
-releaseCommitMessage := s"Set version to ${version.value}"
+releaseCrossBuild       := true
+releaseTagComment       := s"Release ${version.value}"
+releaseCommitMessage    := s"Set version to ${version.value}"
+releaseUseGlobalVersion := false // so that an unscoped version in `version.sbt` works
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -78,10 +78,9 @@ scmInfo  := Some(
   )
 )
 
-releaseCrossBuild       := true
-releaseTagComment       := s"Release ${version.value}"
-releaseCommitMessage    := s"Set version to ${version.value}"
-releaseUseGlobalVersion := false // so that an unscoped version in `version.sbt` works
+releaseCrossBuild    := true
+releaseTagComment    := s"Release ${version.value}"
+releaseCommitMessage := s"Set version to ${version.value}"
 
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -134,7 +134,9 @@ lazy val caching = module(project, "caching")
     libraryDependencies ++= Seq(
       Scaffeine,
       Specs2_4Core % Test
-    )
+    ),
+    // Workaround for duplicate sbt-boilerplate generation under sbt2+; revisit upon updates
+    Compile / packageSrc / mappings ~= (xs => xs.distinct)
   )
 
 lazy val circe = module(project, "circe")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.27.5-SNAPSHOT"
+ThisBuild / version := "0.27.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.27.5"
+ThisBuild / version := "0.27.5-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.27.5-SNAPSHOT"
+version := "0.27.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.27.5"
+ThisBuild / version := "0.27.6-SNAPSHOT"


### PR DESCRIPTION
<!--
Please include a summary of the change. Please also include relevant motivation and context. Consider describing the type of change (if it's a new feature, a bug fix, a refactor...).
-->

This release (first after the upgrade to sbt2) had some hiccups.

```
[error] (caching / Compile / packageSrc) java.util.zip.ZipException: duplicate entry: com/kevel/apso/caching/CachedFunctionsExtras.scala
```

Also, for future reference, for `sbt-release` to work properly in sbt2, `version` must still be scoped under `ThisBuild`, which we removed manually in https://github.com/adzerk/apso/commit/a20021712b47bd6ef0e54fe3b54f2f29d4c4c8ed.

### Does this change relate to existing issues or pull requests?

No. This fixes the release process.

<!--
Include links to issues that should be fixed with this change or that are related to this change.
If this change depends on existing pull requests, also include a link to them here.
If this change needs a follow up, describe what still needs to be done, including links to already opened issues or pull requests.
-->

### Does this change require an update to the documentation?

No.

<!--
If relevant, please consider reflecting the changes you are introducing in the documentation.
-->

### How has this been tested?

Releasing 0.27.5.

<!--
Please describe the tests you ran to verify your change.
Provide reproducible instructions.
-->
